### PR TITLE
pnpm - Remove Symlink + dis-allow pnpm constrain on inheriting repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           node-version: 16.x
       - uses: actions/checkout@v2
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.11.0
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@
 name: Node.js CI
 on:
   push:
-    branches: main
+    branches: master
   pull_request:
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: Node.js CI
+on:
+  push:
+    branches: main
+  pull_request:
+jobs:
+  build:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - uses: actions/checkout@v2
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - run: pnpm i
+      - run: forge build
+      - run: pnpm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern=*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "test"
   },
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "test": "forge test",
     "prepare": "husky install",
     "build": "tsc"


### PR DESCRIPTION
Per the discussion surrounding [this tweet](https://twitter.com/paulrberg/status/1737169159052468479?s=46&t=BikgFq4uEMPdzAI91x1YLA) 

pnpm will now install a flat dependency structure, and removes the requirement that repositories inheriting from this repo use pnpm.

Also ensure build + passing tests on PR + push to master