### PR TITLE
build: update deps to rm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,30 +17,27 @@
   "dependencies": {
     "@chainlink/contracts": "^0.6.1",
     "@openzeppelin/contracts": "^5.0.1",
-    "@solidity-parser/parser": "^0.17.0",
-    "@types/fs-extra": "^11.0.1",
-    "@types/node": "^18.15.11",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^18.19.7",
     "change-case": "^4.1.2",
-    "commander": "^10.0.0",
-    "date-fns": "^2.29.3",
+    "commander": "^10.0.1",
+    "date-fns": "^2.30.0",
     "ds-test": "github:dapphub/ds-test",
     "forge-std": "github:foundry-rs/forge-std#e8a047e3f40f13fa37af6fe14e6e06283d9a060e",
-    "fs-extra": "^11.1.1",
+    "fs-extra": "^11.2.0",
     "husky": "^8.0.3",
-    "lint-staged": "^13.1.2",
-    "nodemon": "^3.0.1",
-    "prettier": "^2.8.4",
-    "prettier-plugin-solidity": "^1.1.3",
-    "solc": "^0.8.19",
-    "solhint": "^3.4.0",
-    "solhint-plugin-prettier": "^0.0.5",
-    "solidity-bytes-utils": "github:GNSPS/solidity-bytes-utils",
-    "solidity-parser": "^0.4.0",
+    "lint-staged": "^13.3.0",
+    "prettier": "^3.2.2",
+    "prettier-plugin-solidity": "^1.3.1",
+    "solc": "^0.8.23",
+    "solhint": "^3.6.2",
+    "solhint-plugin-prettier": "^0.1.0",
+    "solidity-bytes-utils": "^0.8.2",
     "toml": "^3.0.0",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.0.3"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   },
   "devDependencies": {
-    "glob": "^10.2.1"
+    "glob": "^10.3.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: "6.0"
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   "@chainlink/contracts":
     specifier: ^0.6.1
@@ -11,23 +7,20 @@ dependencies:
   "@openzeppelin/contracts":
     specifier: ^5.0.1
     version: 5.0.1
-  "@solidity-parser/parser":
-    specifier: ^0.17.0
-    version: 0.17.0
   "@types/fs-extra":
-    specifier: ^11.0.1
+    specifier: ^11.0.4
     version: 11.0.4
   "@types/node":
-    specifier: ^18.15.11
-    version: 18.19.3
+    specifier: ^18.19.7
+    version: 18.19.7
   change-case:
     specifier: ^4.1.2
     version: 4.1.2
   commander:
-    specifier: ^10.0.0
+    specifier: ^10.0.1
     version: 10.0.1
   date-fns:
-    specifier: ^2.29.3
+    specifier: ^2.30.0
     version: 2.30.0
   ds-test:
     specifier: github:dapphub/ds-test
@@ -36,63 +29,48 @@ dependencies:
     specifier: github:foundry-rs/forge-std#e8a047e3f40f13fa37af6fe14e6e06283d9a060e
     version: github.com/foundry-rs/forge-std/e8a047e3f40f13fa37af6fe14e6e06283d9a060e
   fs-extra:
-    specifier: ^11.1.1
+    specifier: ^11.2.0
     version: 11.2.0
   husky:
     specifier: ^8.0.3
     version: 8.0.3
   lint-staged:
-    specifier: ^13.1.2
+    specifier: ^13.3.0
     version: 13.3.0
-  nodemon:
-    specifier: ^3.0.1
-    version: 3.0.2
   prettier:
-    specifier: ^2.8.4
-    version: 2.8.8
+    specifier: ^3.2.2
+    version: 3.2.2
   prettier-plugin-solidity:
-    specifier: ^1.1.3
-    version: 1.2.0(prettier@2.8.8)
+    specifier: ^1.3.1
+    version: 1.3.1(prettier@3.2.2)
   solc:
-    specifier: ^0.8.19
+    specifier: ^0.8.23
     version: 0.8.23
   solhint:
-    specifier: ^3.4.0
+    specifier: ^3.6.2
     version: 3.6.2(typescript@5.3.3)
   solhint-plugin-prettier:
-    specifier: ^0.0.5
-    version: 0.0.5(prettier-plugin-solidity@1.2.0)(prettier@2.8.8)
+    specifier: ^0.1.0
+    version: 0.1.0(prettier-plugin-solidity@1.3.1)(prettier@3.2.2)
   solidity-bytes-utils:
-    specifier: github:GNSPS/solidity-bytes-utils
-    version: github.com/GNSPS/solidity-bytes-utils/42221d3ee53aff8888057fb9f3b7a8fc42c290f8(@babel/core@7.23.7)
-  solidity-parser:
-    specifier: ^0.4.0
-    version: 0.4.0
+    specifier: ^0.8.2
+    version: 0.8.2
   toml:
     specifier: ^3.0.0
     version: 3.0.0
   ts-node:
-    specifier: ^10.9.1
-    version: 10.9.2(@types/node@18.19.3)(typescript@5.3.3)
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@18.19.7)(typescript@5.3.3)
   typescript:
-    specifier: ^5.0.3
+    specifier: ^5.3.3
     version: 5.3.3
 
 devDependencies:
   glob:
-    specifier: ^10.2.1
+    specifier: ^10.3.10
     version: 10.3.10
 
 packages:
-  /@ampproject/remapping@2.2.1:
-    resolution:
-      { integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg== }
-    engines: { node: ">=6.0.0" }
-    dependencies:
-      "@jridgewell/gen-mapping": 0.3.3
-      "@jridgewell/trace-mapping": 0.3.21
-    dev: false
-
   /@babel/code-frame@7.23.5:
     resolution:
       { integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA== }
@@ -102,171 +80,10 @@ packages:
       chalk: 2.4.2
     dev: false
 
-  /@babel/compat-data@7.23.5:
-    resolution:
-      { integrity: sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
-  /@babel/core@7.23.7:
-    resolution:
-      { integrity: sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@ampproject/remapping": 2.2.1
-      "@babel/code-frame": 7.23.5
-      "@babel/generator": 7.23.6
-      "@babel/helper-compilation-targets": 7.23.6
-      "@babel/helper-module-transforms": 7.23.3(@babel/core@7.23.7)
-      "@babel/helpers": 7.23.8
-      "@babel/parser": 7.23.6
-      "@babel/template": 7.22.15
-      "@babel/traverse": 7.23.7
-      "@babel/types": 7.23.6
-      convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@5.5.0)
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/generator@7.23.6:
-    resolution:
-      { integrity: sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/types": 7.23.6
-      "@jridgewell/gen-mapping": 0.3.3
-      "@jridgewell/trace-mapping": 0.3.21
-      jsesc: 2.5.2
-    dev: false
-
-  /@babel/helper-compilation-targets@7.23.6:
-    resolution:
-      { integrity: sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/compat-data": 7.23.5
-      "@babel/helper-validator-option": 7.23.5
-      browserslist: 4.22.2
-      lru-cache: 5.1.1
-      semver: 6.3.1
-    dev: false
-
-  /@babel/helper-define-polyfill-provider@0.4.3(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug== }
-    peerDependencies:
-      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      "@babel/core": 7.23.7
-      "@babel/helper-compilation-targets": 7.23.6
-      "@babel/helper-plugin-utils": 7.22.5
-      debug: 4.3.4(supports-color@5.5.0)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.8
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-environment-visitor@7.22.20:
-    resolution:
-      { integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
-  /@babel/helper-function-name@7.23.0:
-    resolution:
-      { integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/template": 7.22.15
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/helper-hoist-variables@7.22.5:
-    resolution:
-      { integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/helper-module-imports@7.22.15:
-    resolution:
-      { integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ== }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0
-    dependencies:
-      "@babel/core": 7.23.7
-      "@babel/helper-environment-visitor": 7.22.20
-      "@babel/helper-module-imports": 7.22.15
-      "@babel/helper-simple-access": 7.22.5
-      "@babel/helper-split-export-declaration": 7.22.6
-      "@babel/helper-validator-identifier": 7.22.20
-    dev: false
-
-  /@babel/helper-plugin-utils@7.22.5:
-    resolution:
-      { integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
-  /@babel/helper-simple-access@7.22.5:
-    resolution:
-      { integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/helper-split-export-declaration@7.22.6:
-    resolution:
-      { integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/helper-string-parser@7.23.4:
-    resolution:
-      { integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution:
       { integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A== }
     engines: { node: ">=6.9.0" }
-    dev: false
-
-  /@babel/helper-validator-option@7.23.5:
-    resolution:
-      { integrity: sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
-  /@babel/helpers@7.23.8:
-    resolution:
-      { integrity: sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/template": 7.22.15
-      "@babel/traverse": 7.23.7
-      "@babel/types": 7.23.6
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@babel/highlight@7.23.4:
@@ -279,78 +96,12 @@ packages:
       js-tokens: 4.0.0
     dev: false
 
-  /@babel/parser@7.23.6:
+  /@babel/runtime@7.23.8:
     resolution:
-      { integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ== }
-    engines: { node: ">=6.0.0" }
-    hasBin: true
-    dependencies:
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/plugin-transform-runtime@7.23.4(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-ITwqpb6V4btwUG0YJR82o2QvmWrLgDnx/p2A3CTPYGaRgULkDiC0DRA2C4jlRB9uXGUEfaSS/IGHfVW+ohzYDw== }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    dependencies:
-      "@babel/core": 7.23.7
-      "@babel/helper-module-imports": 7.22.15
-      "@babel/helper-plugin-utils": 7.22.5
-      babel-plugin-polyfill-corejs2: 0.4.6(@babel/core@7.23.7)
-      babel-plugin-polyfill-corejs3: 0.8.6(@babel/core@7.23.7)
-      babel-plugin-polyfill-regenerator: 0.5.3(@babel/core@7.23.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/runtime@7.23.5:
-    resolution:
-      { integrity: sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w== }
+      { integrity: sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw== }
     engines: { node: ">=6.9.0" }
     dependencies:
-      regenerator-runtime: 0.14.0
-    dev: false
-
-  /@babel/template@7.22.15:
-    resolution:
-      { integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/code-frame": 7.23.5
-      "@babel/parser": 7.23.6
-      "@babel/types": 7.23.6
-    dev: false
-
-  /@babel/traverse@7.23.7:
-    resolution:
-      { integrity: sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/code-frame": 7.23.5
-      "@babel/generator": 7.23.6
-      "@babel/helper-environment-visitor": 7.22.20
-      "@babel/helper-function-name": 7.23.0
-      "@babel/helper-hoist-variables": 7.22.5
-      "@babel/helper-split-export-declaration": 7.22.6
-      "@babel/parser": 7.23.6
-      "@babel/types": 7.23.6
-      debug: 4.3.4(supports-color@5.5.0)
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/types@7.23.6:
-    resolution:
-      { integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg== }
-    engines: { node: ">=6.9.0" }
-    dependencies:
-      "@babel/helper-string-parser": 7.23.4
-      "@babel/helper-validator-identifier": 7.22.20
-      to-fast-properties: 2.0.0
+      regenerator-runtime: 0.14.1
     dev: false
 
   /@chainlink/contracts@0.6.1(ethers@5.7.2):
@@ -409,42 +160,10 @@ packages:
       "@ethersproject/transactions": 5.7.0
       "@ethersproject/web": 5.7.1
       bufio: 1.2.1
-      chai: 4.3.10
+      chai: 4.4.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: false
-
-  /@ethereumjs/common@2.5.0:
-    resolution:
-      { integrity: sha512-DEHjW6e38o+JmB/NO3GZBpW4lpaiBpkFgXF6jLcJ6gETBYpEyaA5nTimsWBUJR3Vmtm/didUEbNjajskugZORg== }
-    dependencies:
-      crc-32: 1.2.2
-      ethereumjs-util: 7.1.5
-    dev: false
-
-  /@ethereumjs/common@2.6.5:
-    resolution:
-      { integrity: sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA== }
-    dependencies:
-      crc-32: 1.2.2
-      ethereumjs-util: 7.1.5
-    dev: false
-
-  /@ethereumjs/tx@3.3.2:
-    resolution:
-      { integrity: sha512-6AaJhwg4ucmwTvw/1qLaZUX5miWrwZ4nLOUsKyb/HtzS3BMw/CasKhdi1ims9mBKeK9sOJCH4qGKOBGyJCeeog== }
-    dependencies:
-      "@ethereumjs/common": 2.6.5
-      ethereumjs-util: 7.1.5
-    dev: false
-
-  /@ethereumjs/tx@3.5.2:
-    resolution:
-      { integrity: sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw== }
-    dependencies:
-      "@ethereumjs/common": 2.6.5
-      ethereumjs-util: 7.1.5
     dev: false
 
   /@ethersproject/abi@5.7.0:
@@ -805,25 +524,9 @@ packages:
       wrap-ansi-cjs: /wrap-ansi@7.0.0
     dev: true
 
-  /@jridgewell/gen-mapping@0.3.3:
-    resolution:
-      { integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ== }
-    engines: { node: ">=6.0.0" }
-    dependencies:
-      "@jridgewell/set-array": 1.1.2
-      "@jridgewell/sourcemap-codec": 1.4.15
-      "@jridgewell/trace-mapping": 0.3.21
-    dev: false
-
   /@jridgewell/resolve-uri@3.1.1:
     resolution:
       { integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA== }
-    engines: { node: ">=6.0.0" }
-    dev: false
-
-  /@jridgewell/set-array@1.1.2:
-    resolution:
-      { integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw== }
     engines: { node: ">=6.0.0" }
     dev: false
 
@@ -832,47 +535,12 @@ packages:
       { integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg== }
     dev: false
 
-  /@jridgewell/trace-mapping@0.3.21:
-    resolution:
-      { integrity: sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g== }
-    dependencies:
-      "@jridgewell/resolve-uri": 3.1.1
-      "@jridgewell/sourcemap-codec": 1.4.15
-    dev: false
-
   /@jridgewell/trace-mapping@0.3.9:
     resolution:
       { integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ== }
     dependencies:
       "@jridgewell/resolve-uri": 3.1.1
       "@jridgewell/sourcemap-codec": 1.4.15
-    dev: false
-
-  /@metamask/eth-sig-util@4.0.1:
-    resolution:
-      { integrity: sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ== }
-    engines: { node: ">=12.0.0" }
-    dependencies:
-      ethereumjs-abi: 0.6.8
-      ethereumjs-util: 6.2.1
-      ethjs-util: 0.1.6
-      tweetnacl: 1.0.3
-      tweetnacl-util: 0.15.1
-    dev: false
-
-  /@metamask/safe-event-emitter@2.0.0:
-    resolution:
-      { integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q== }
-    dev: false
-
-  /@noble/hashes@1.1.2:
-    resolution:
-      { integrity: sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA== }
-    dev: false
-
-  /@noble/secp256k1@1.6.3:
-    resolution:
-      { integrity: sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ== }
     dev: false
 
   /@openzeppelin/contracts-upgradeable@4.9.5:
@@ -903,32 +571,13 @@ packages:
     dev: true
     optional: true
 
-  /@scure/base@1.1.3:
+  /@prettier/sync@0.3.0(prettier@3.2.2):
     resolution:
-      { integrity: sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q== }
-    dev: false
-
-  /@scure/bip32@1.1.0:
-    resolution:
-      { integrity: sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q== }
+      { integrity: sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw== }
+    peerDependencies:
+      prettier: ^3.0.0
     dependencies:
-      "@noble/hashes": 1.1.2
-      "@noble/secp256k1": 1.6.3
-      "@scure/base": 1.1.3
-    dev: false
-
-  /@scure/bip39@1.1.0:
-    resolution:
-      { integrity: sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w== }
-    dependencies:
-      "@noble/hashes": 1.1.2
-      "@scure/base": 1.1.3
-    dev: false
-
-  /@sindresorhus/is@4.6.0:
-    resolution:
-      { integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw== }
-    engines: { node: ">=10" }
+      prettier: 3.2.2
     dev: false
 
   /@solidity-parser/parser@0.16.2:
@@ -941,57 +590,6 @@ packages:
   /@solidity-parser/parser@0.17.0:
     resolution:
       { integrity: sha512-Nko8R0/kUo391jsEHHxrGM07QFdnPGvlmox4rmH0kNiNAashItAilhy4Mv4pK5gQmW5f4sXAF58fwJbmlkGcVw== }
-    dev: false
-
-  /@szmarczak/http-timer@4.0.6:
-    resolution:
-      { integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w== }
-    engines: { node: ">=10" }
-    dependencies:
-      defer-to-connect: 2.0.1
-    dev: false
-
-  /@szmarczak/http-timer@5.0.1:
-    resolution:
-      { integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw== }
-    engines: { node: ">=14.16" }
-    dependencies:
-      defer-to-connect: 2.0.1
-    dev: false
-
-  /@truffle/hdwallet-provider@2.1.15(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-I5cSS+5LygA3WFzru9aC5+yDXVowEEbLCx0ckl/RqJ2/SCiYXkzYlR5/DjjDJuCtYhivhrn2RP9AheeFlRF+qw== }
-    engines: { node: ^16.20 || ^18.16 || >=20 }
-    dependencies:
-      "@ethereumjs/common": 2.6.5
-      "@ethereumjs/tx": 3.5.2
-      "@metamask/eth-sig-util": 4.0.1
-      "@truffle/hdwallet": 0.1.4
-      "@types/ethereum-protocol": 1.0.5
-      "@types/web3": 1.0.20
-      "@types/web3-provider-engine": 14.0.4
-      ethereum-cryptography: 1.1.2
-      ethereum-protocol: 1.0.1
-      ethereumjs-util: 7.1.5
-      web3: 1.10.0
-      web3-provider-engine: 16.0.3(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - "@babel/core"
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /@truffle/hdwallet@0.1.4:
-    resolution:
-      { integrity: sha512-D3SN0iw3sMWUXjWAedP6RJtopo9qQXYi80inzbtcsoso4VhxFxCwFvCErCl4b27AEJ9pkAtgnxEFRaSKdMmi1Q== }
-    engines: { node: ^16.20 || ^18.16 || >=20 }
-    dependencies:
-      ethereum-cryptography: 1.1.2
-      keccak: 3.0.2
-      secp256k1: 4.0.3
     dev: false
 
   /@tsconfig/node10@1.0.9:
@@ -1014,159 +612,37 @@ packages:
       { integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA== }
     dev: false
 
-  /@types/bn.js@4.11.6:
-    resolution:
-      { integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/bn.js@5.1.5:
-    resolution:
-      { integrity: sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/cacheable-request@6.0.3:
-    resolution:
-      { integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw== }
-    dependencies:
-      "@types/http-cache-semantics": 4.0.4
-      "@types/keyv": 3.1.4
-      "@types/node": 18.19.3
-      "@types/responselike": 1.0.3
-    dev: false
-
-  /@types/ethereum-protocol@1.0.5:
-    resolution:
-      { integrity: sha512-4wr+t2rYbwMmDrT447SGzE/43Z0EN++zyHCBoruIx32fzXQDxVa1rnQbYwPO8sLP2OugE/L8KaAIJC5kieUuBg== }
-    dependencies:
-      bignumber.js: 7.2.1
-    dev: false
-
   /@types/fs-extra@11.0.4:
     resolution:
       { integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ== }
     dependencies:
       "@types/jsonfile": 6.1.4
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/http-cache-semantics@4.0.4:
-    resolution:
-      { integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA== }
+      "@types/node": 18.19.7
     dev: false
 
   /@types/jsonfile@6.1.4:
     resolution:
       { integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ== }
     dependencies:
-      "@types/node": 18.19.3
+      "@types/node": 18.19.7
     dev: false
 
-  /@types/keyv@3.1.4:
+  /@types/node@18.19.7:
     resolution:
-      { integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/node@12.20.55:
-    resolution:
-      { integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ== }
-    dev: false
-
-  /@types/node@18.19.3:
-    resolution:
-      { integrity: sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg== }
+      { integrity: sha512-IGRJfoNX10N/PfrReRZ1br/7SQ+2vF/tK3KXNwzXz82D32z5dMQEoOlFew18nLSN+vMNcLY4GrKfzwi/yWI8/w== }
     dependencies:
       undici-types: 5.26.5
     dev: false
 
-  /@types/pbkdf2@3.1.2:
+  /acorn-walk@8.3.2:
     resolution:
-      { integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/responselike@1.0.3:
-    resolution:
-      { integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/secp256k1@4.0.6:
-    resolution:
-      { integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ== }
-    dependencies:
-      "@types/node": 18.19.3
-    dev: false
-
-  /@types/underscore@1.11.15:
-    resolution:
-      { integrity: sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g== }
-    dev: false
-
-  /@types/web3-provider-engine@14.0.4:
-    resolution:
-      { integrity: sha512-59wFvtceRmWXfQFoH8qtFIQZf6B7PqBwgBBmZLu4SjRK6pycnjV8K+jihbaGOFwHjTPcPFm15m+CS6I0BBm4lw== }
-    dependencies:
-      "@types/ethereum-protocol": 1.0.5
-    dev: false
-
-  /@types/web3@1.0.20:
-    resolution:
-      { integrity: sha512-KTDlFuYjzCUlBDGt35Ir5QRtyV9klF84MMKUsEJK10sTWga/71V+8VYLT7yysjuBjaOx2uFYtIWNGoz3yrNDlg== }
-    dependencies:
-      "@types/bn.js": 5.1.5
-      "@types/underscore": 1.11.15
-    dev: false
-
-  /abbrev@1.1.1:
-    resolution:
-      { integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q== }
-    dev: false
-
-  /abortcontroller-polyfill@1.7.5:
-    resolution:
-      { integrity: sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ== }
-    dev: false
-
-  /abstract-leveldown@2.6.3:
-    resolution:
-      { integrity: sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA== }
-    dependencies:
-      xtend: 4.0.2
-    dev: false
-
-  /abstract-leveldown@2.7.2:
-    resolution:
-      { integrity: sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w== }
-    dependencies:
-      xtend: 4.0.2
-    dev: false
-
-  /accepts@1.3.8:
-    resolution:
-      { integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw== }
-    engines: { node: ">= 0.6" }
-    dependencies:
-      mime-types: 2.1.35
-      negotiator: 0.6.3
-    dev: false
-
-  /acorn-walk@8.3.1:
-    resolution:
-      { integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw== }
+      { integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A== }
     engines: { node: ">=0.4.0" }
     dev: false
 
-  /acorn@8.11.2:
+  /acorn@8.11.3:
     resolution:
-      { integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w== }
+      { integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg== }
     engines: { node: ">=0.4.0" }
     hasBin: true
     dev: false
@@ -1202,12 +678,6 @@ packages:
     engines: { node: ">=12" }
     dependencies:
       type-fest: 1.4.0
-    dev: false
-
-  /ansi-regex@2.1.1:
-    resolution:
-      { integrity: sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA== }
-    engines: { node: ">=0.10.0" }
     dev: false
 
   /ansi-regex@5.0.1:
@@ -1251,15 +721,6 @@ packages:
       { integrity: sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ== }
     dev: false
 
-  /anymatch@3.1.3:
-    resolution:
-      { integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw== }
-    engines: { node: ">= 8" }
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-    dev: false
-
   /arg@4.1.3:
     resolution:
       { integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA== }
@@ -1268,24 +729,6 @@ packages:
   /argparse@2.0.1:
     resolution:
       { integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q== }
-    dev: false
-
-  /array-flatten@1.1.1:
-    resolution:
-      { integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg== }
-    dev: false
-
-  /asn1@0.2.6:
-    resolution:
-      { integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ== }
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
-  /assert-plus@1.0.0:
-    resolution:
-      { integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw== }
-    engines: { node: ">=0.8" }
     dev: false
 
   /assertion-error@1.1.0:
@@ -1304,162 +747,13 @@ packages:
     engines: { node: ">=8" }
     dev: false
 
-  /async-eventemitter@0.2.4:
-    resolution:
-      { integrity: sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw== }
-    dependencies:
-      async: 2.6.4
-    dev: false
-
-  /async-limiter@1.0.1:
-    resolution:
-      { integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ== }
-    dev: false
-
-  /async-mutex@0.2.6:
-    resolution:
-      { integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw== }
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /async@1.5.2:
-    resolution:
-      { integrity: sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w== }
-    dev: false
-
-  /async@2.6.4:
-    resolution:
-      { integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA== }
-    dependencies:
-      lodash: 4.17.21
-    dev: false
-
-  /asynckit@0.4.0:
-    resolution:
-      { integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q== }
-    dev: false
-
-  /available-typed-arrays@1.0.5:
-    resolution:
-      { integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /aws-sign2@0.7.0:
-    resolution:
-      { integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA== }
-    dev: false
-
-  /aws4@1.12.0:
-    resolution:
-      { integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg== }
-    dev: false
-
-  /babel-plugin-polyfill-corejs2@0.4.6(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q== }
-    peerDependencies:
-      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      "@babel/compat-data": 7.23.5
-      "@babel/core": 7.23.7
-      "@babel/helper-define-polyfill-provider": 0.4.3(@babel/core@7.23.7)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /babel-plugin-polyfill-corejs3@0.8.6(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ== }
-    peerDependencies:
-      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      "@babel/core": 7.23.7
-      "@babel/helper-define-polyfill-provider": 0.4.3(@babel/core@7.23.7)
-      core-js-compat: 3.34.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /babel-plugin-polyfill-regenerator@0.5.3(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw== }
-    peerDependencies:
-      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-    dependencies:
-      "@babel/core": 7.23.7
-      "@babel/helper-define-polyfill-provider": 0.4.3(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /backoff@2.5.0:
-    resolution:
-      { integrity: sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA== }
-    engines: { node: ">= 0.6" }
-    dependencies:
-      precond: 0.2.3
-    dev: false
-
   /balanced-match@1.0.2:
     resolution:
       { integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw== }
 
-  /base-x@3.0.9:
-    resolution:
-      { integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ== }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /base64-js@1.5.1:
-    resolution:
-      { integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA== }
-    dev: false
-
-  /bcrypt-pbkdf@1.0.2:
-    resolution:
-      { integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w== }
-    dependencies:
-      tweetnacl: 0.14.5
-    dev: false
-
   /bech32@1.1.4:
     resolution:
       { integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ== }
-    dev: false
-
-  /bignumber.js@7.2.1:
-    resolution:
-      { integrity: sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ== }
-    dev: false
-
-  /bignumber.js@9.1.2:
-    resolution:
-      { integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug== }
-    dev: false
-
-  /binary-extensions@2.2.0:
-    resolution:
-      { integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA== }
-    engines: { node: ">=8" }
-    dev: false
-
-  /blakejs@1.2.1:
-    resolution:
-      { integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ== }
-    dev: false
-
-  /bluebird@3.7.2:
-    resolution:
-      { integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg== }
-    dev: false
-
-  /bn.js@4.11.6:
-    resolution:
-      { integrity: sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA== }
     dev: false
 
   /bn.js@4.12.0:
@@ -1470,56 +764,6 @@ packages:
   /bn.js@5.2.1:
     resolution:
       { integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ== }
-    dev: false
-
-  /body-parser@1.20.1:
-    resolution:
-      { integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw== }
-    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.11.0
-      raw-body: 2.5.1
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /body-parser@1.20.2:
-    resolution:
-      { integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA== }
-    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.11.0
-      raw-body: 2.5.2
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /brace-expansion@1.1.11:
-    resolution:
-      { integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA== }
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
     dev: false
 
   /brace-expansion@2.0.1:
@@ -1541,125 +785,10 @@ packages:
       { integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w== }
     dev: false
 
-  /browserify-aes@1.2.0:
-    resolution:
-      { integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA== }
-    dependencies:
-      buffer-xor: 1.0.3
-      cipher-base: 1.0.4
-      create-hash: 1.2.0
-      evp_bytestokey: 1.0.3
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-    dev: false
-
-  /browserslist@4.22.2:
-    resolution:
-      { integrity: sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A== }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001566
-      electron-to-chromium: 1.4.608
-      node-releases: 2.0.14
-      update-browserslist-db: 1.0.13(browserslist@4.22.2)
-    dev: false
-
-  /bs58@4.0.1:
-    resolution:
-      { integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw== }
-    dependencies:
-      base-x: 3.0.9
-    dev: false
-
-  /bs58check@2.1.2:
-    resolution:
-      { integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA== }
-    dependencies:
-      bs58: 4.0.1
-      create-hash: 1.2.0
-      safe-buffer: 5.2.1
-    dev: false
-
-  /btoa@1.2.1:
-    resolution:
-      { integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g== }
-    engines: { node: ">= 0.4.0" }
-    hasBin: true
-    dev: false
-
-  /buffer-to-arraybuffer@0.0.5:
-    resolution:
-      { integrity: sha512-3dthu5CYiVB1DEJp61FtApNnNndTckcqe4pFcLdvHtrpG+kcyekCJKg4MRiDcFW7A6AODnXB9U4dwQiCW5kzJQ== }
-    dev: false
-
-  /buffer-xor@1.0.3:
-    resolution:
-      { integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ== }
-    dev: false
-
-  /buffer@5.7.1:
-    resolution:
-      { integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ== }
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
-
-  /bufferutil@4.0.8:
-    resolution:
-      { integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw== }
-    engines: { node: ">=6.14.2" }
-    requiresBuild: true
-    dependencies:
-      node-gyp-build: 4.7.1
-    dev: false
-
   /bufio@1.2.1:
     resolution:
       { integrity: sha512-9oR3zNdupcg/Ge2sSHQF3GX+kmvL/fTPvD0nd5AGLq8SjUYnTz+SlFjK/GXidndbZtIj+pVKXiWeR9w6e9wKCA== }
     engines: { node: ">=14.0.0" }
-    dev: false
-
-  /bytes@3.1.2:
-    resolution:
-      { integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /cacheable-lookup@5.0.4:
-    resolution:
-      { integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA== }
-    engines: { node: ">=10.6.0" }
-    dev: false
-
-  /cacheable-lookup@6.1.0:
-    resolution:
-      { integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww== }
-    engines: { node: ">=10.6.0" }
-    dev: false
-
-  /cacheable-request@7.0.4:
-    resolution:
-      { integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg== }
-    engines: { node: ">=8" }
-    dependencies:
-      clone-response: 1.0.3
-      get-stream: 5.2.0
-      http-cache-semantics: 4.1.1
-      keyv: 4.5.4
-      lowercase-keys: 2.0.0
-      normalize-url: 6.1.0
-      responselike: 2.0.1
-    dev: false
-
-  /call-bind@1.0.5:
-    resolution:
-      { integrity: sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ== }
-    dependencies:
-      function-bind: 1.1.2
-      get-intrinsic: 1.2.2
-      set-function-length: 1.1.1
     dev: false
 
   /callsites@3.1.0:
@@ -1676,17 +805,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /camelcase@3.0.0:
-    resolution:
-      { integrity: sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /caniuse-lite@1.0.30001566:
-    resolution:
-      { integrity: sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA== }
-    dev: false
-
   /capital-case@1.0.4:
     resolution:
       { integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A== }
@@ -1696,14 +814,9 @@ packages:
       upper-case-first: 2.0.2
     dev: false
 
-  /caseless@0.12.0:
+  /chai@4.4.1:
     resolution:
-      { integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw== }
-    dev: false
-
-  /chai@4.3.10:
-    resolution:
-      { integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g== }
+      { integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g== }
     engines: { node: ">=4" }
     dependencies:
       assertion-error: 1.1.0
@@ -1765,60 +878,6 @@ packages:
       get-func-name: 2.0.2
     dev: false
 
-  /checkpoint-store@1.1.0:
-    resolution:
-      { integrity: sha512-J/NdY2WvIx654cc6LWSq/IYFFCUf75fFTgwzFnmbqyORH4MwgiQCgswLLKBGzmsyTI5V7i5bp/So6sMbDWhedg== }
-    dependencies:
-      functional-red-black-tree: 1.0.1
-    dev: false
-
-  /chokidar@3.5.3:
-    resolution:
-      { integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw== }
-    engines: { node: ">= 8.10.0" }
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-    dev: false
-
-  /chownr@1.1.4:
-    resolution:
-      { integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg== }
-    dev: false
-
-  /cids@0.7.5:
-    resolution:
-      { integrity: sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA== }
-    engines: { node: ">=4.0.0", npm: ">=3.0.0" }
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      buffer: 5.7.1
-      class-is: 1.1.0
-      multibase: 0.6.1
-      multicodec: 1.0.4
-      multihashes: 0.4.21
-    dev: false
-
-  /cipher-base@1.0.4:
-    resolution:
-      { integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q== }
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-    dev: false
-
-  /class-is@1.1.0:
-    resolution:
-      { integrity: sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw== }
-    dev: false
-
   /cli-cursor@4.0.0:
     resolution:
       { integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg== }
@@ -1834,34 +893,6 @@ packages:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 5.1.2
-    dev: false
-
-  /cliui@3.2.0:
-    resolution:
-      { integrity: sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w== }
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-      wrap-ansi: 2.1.0
-    dev: false
-
-  /clone-response@1.0.3:
-    resolution:
-      { integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA== }
-    dependencies:
-      mimic-response: 1.0.1
-    dev: false
-
-  /clone@2.1.2:
-    resolution:
-      { integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w== }
-    engines: { node: ">=0.8" }
-    dev: false
-
-  /code-point-at@1.1.0:
-    resolution:
-      { integrity: sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA== }
-    engines: { node: ">=0.10.0" }
     dev: false
 
   /color-convert@1.9.3:
@@ -1892,23 +923,9 @@ packages:
       { integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w== }
     dev: false
 
-  /combined-stream@1.0.8:
-    resolution:
-      { integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /command-exists@1.2.9:
     resolution:
       { integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w== }
-    dev: false
-
-  /commander@0.6.1:
-    resolution:
-      { integrity: sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw== }
-    engines: { node: ">= 0.4.x" }
     dev: false
 
   /commander@10.0.1:
@@ -1923,21 +940,10 @@ packages:
     engines: { node: ">=16" }
     dev: false
 
-  /commander@2.3.0:
-    resolution:
-      { integrity: sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ== }
-    engines: { node: ">= 0.6.x" }
-    dev: false
-
   /commander@8.3.0:
     resolution:
       { integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww== }
     engines: { node: ">= 12" }
-    dev: false
-
-  /concat-map@0.0.1:
-    resolution:
-      { integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg== }
     dev: false
 
   /constant-case@3.0.4:
@@ -1947,71 +953,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case: 2.0.2
-    dev: false
-
-  /content-disposition@0.5.4:
-    resolution:
-      { integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ== }
-    engines: { node: ">= 0.6" }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /content-hash@2.5.2:
-    resolution:
-      { integrity: sha512-FvIQKy0S1JaWV10sMsA7TRx8bpU+pqPkhbsfvOJAdjRXvYxEckAwQWGwtRjiaJfh+E0DvcWUGqcdjwMGFjsSdw== }
-    dependencies:
-      cids: 0.7.5
-      multicodec: 0.5.7
-      multihashes: 0.4.21
-    dev: false
-
-  /content-type@1.0.5:
-    resolution:
-      { integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /convert-source-map@2.0.0:
-    resolution:
-      { integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg== }
-    dev: false
-
-  /cookie-signature@1.0.6:
-    resolution:
-      { integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ== }
-    dev: false
-
-  /cookie@0.5.0:
-    resolution:
-      { integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /core-js-compat@3.34.0:
-    resolution:
-      { integrity: sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA== }
-    dependencies:
-      browserslist: 4.22.2
-    dev: false
-
-  /core-util-is@1.0.2:
-    resolution:
-      { integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ== }
-    dev: false
-
-  /core-util-is@1.0.3:
-    resolution:
-      { integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ== }
-    dev: false
-
-  /cors@2.8.5:
-    resolution:
-      { integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g== }
-    engines: { node: ">= 0.10" }
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
     dev: false
 
   /cosmiconfig@8.3.6(typescript@5.3.3):
@@ -2031,58 +972,9 @@ packages:
       typescript: 5.3.3
     dev: false
 
-  /crc-32@1.2.2:
-    resolution:
-      { integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ== }
-    engines: { node: ">=0.8" }
-    hasBin: true
-    dev: false
-
-  /create-hash@1.2.0:
-    resolution:
-      { integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg== }
-    dependencies:
-      cipher-base: 1.0.4
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.2
-      sha.js: 2.4.11
-    dev: false
-
-  /create-hmac@1.1.7:
-    resolution:
-      { integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg== }
-    dependencies:
-      cipher-base: 1.0.4
-      create-hash: 1.2.0
-      inherits: 2.0.4
-      ripemd160: 2.0.2
-      safe-buffer: 5.2.1
-      sha.js: 2.4.11
-    dev: false
-
   /create-require@1.1.1:
     resolution:
       { integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ== }
-    dev: false
-
-  /cross-fetch@2.2.6:
-    resolution:
-      { integrity: sha512-9JZz+vXCmfKUZ68zAptS7k4Nu8e2qcibe7WVZYps7sAgk5R8GYTc+T1WR0v1rlP9HxgARmOX1UTIJZFytajpNA== }
-    dependencies:
-      node-fetch: 2.7.0
-      whatwg-fetch: 2.0.4
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /cross-fetch@3.1.8:
-    resolution:
-      { integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg== }
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
     dev: false
 
   /cross-spawn@7.0.3:
@@ -2094,56 +986,15 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  /d@1.0.1:
-    resolution:
-      { integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA== }
-    dependencies:
-      es5-ext: 0.10.62
-      type: 1.2.0
-    dev: false
-
-  /dashdash@1.14.1:
-    resolution:
-      { integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g== }
-    engines: { node: ">=0.10" }
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
-
   /date-fns@2.30.0:
     resolution:
       { integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw== }
     engines: { node: ">=0.11" }
     dependencies:
-      "@babel/runtime": 7.23.5
+      "@babel/runtime": 7.23.8
     dev: false
 
-  /debug@2.2.0(supports-color@1.2.0):
-    resolution:
-      { integrity: sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw== }
-    peerDependencies:
-      supports-color: "*"
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 0.7.1
-      supports-color: 1.2.0
-    dev: false
-
-  /debug@2.6.9:
-    resolution:
-      { integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA== }
-    peerDependencies:
-      supports-color: "*"
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    dependencies:
-      ms: 2.0.0
-    dev: false
-
-  /debug@4.3.4(supports-color@5.5.0):
+  /debug@4.3.4:
     resolution:
       { integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ== }
     engines: { node: ">=6.0" }
@@ -2154,35 +1005,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 5.5.0
-    dev: false
-
-  /decamelize@1.2.0:
-    resolution:
-      { integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /decode-uri-component@0.2.2:
-    resolution:
-      { integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ== }
-    engines: { node: ">=0.10" }
-    dev: false
-
-  /decompress-response@3.3.0:
-    resolution:
-      { integrity: sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA== }
-    engines: { node: ">=4" }
-    dependencies:
-      mimic-response: 1.0.1
-    dev: false
-
-  /decompress-response@6.0.0:
-    resolution:
-      { integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ== }
-    engines: { node: ">=10" }
-    dependencies:
-      mimic-response: 3.1.0
     dev: false
 
   /deep-eql@4.1.3:
@@ -2193,62 +1015,10 @@ packages:
       type-detect: 4.0.8
     dev: false
 
-  /defer-to-connect@2.0.1:
-    resolution:
-      { integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg== }
-    engines: { node: ">=10" }
-    dev: false
-
-  /deferred-leveldown@1.2.2:
-    resolution:
-      { integrity: sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA== }
-    dependencies:
-      abstract-leveldown: 2.6.3
-    dev: false
-
-  /define-data-property@1.1.1:
-    resolution:
-      { integrity: sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      get-intrinsic: 1.2.2
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.1
-    dev: false
-
-  /delayed-stream@1.0.0:
-    resolution:
-      { integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ== }
-    engines: { node: ">=0.4.0" }
-    dev: false
-
-  /depd@2.0.0:
-    resolution:
-      { integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /destroy@1.2.0:
-    resolution:
-      { integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg== }
-    engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
-    dev: false
-
-  /diff@1.4.0:
-    resolution:
-      { integrity: sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w== }
-    engines: { node: ">=0.3.1" }
-    dev: false
-
   /diff@4.0.2:
     resolution:
       { integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A== }
     engines: { node: ">=0.3.1" }
-    dev: false
-
-  /dom-walk@0.1.2:
-    resolution:
-      { integrity: sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w== }
     dev: false
 
   /dot-case@3.0.4:
@@ -2262,24 +1032,6 @@ packages:
   /eastasianwidth@0.2.0:
     resolution:
       { integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA== }
-
-  /ecc-jsbn@0.1.2:
-    resolution:
-      { integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw== }
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-    dev: false
-
-  /ee-first@1.1.1:
-    resolution:
-      { integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow== }
-    dev: false
-
-  /electron-to-chromium@1.4.608:
-    resolution:
-      { integrity: sha512-J2f/3iIIm3Mo0npneITZ2UPe4B1bg8fTNrFjD8715F/k1BvbviRuqYGkET1PgprrczXYTHFvotbBOmUp6KE0uA== }
-    dev: false
 
   /elliptic@6.5.4:
     resolution:
@@ -2302,27 +1054,6 @@ packages:
     resolution:
       { integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg== }
 
-  /encodeurl@1.0.2:
-    resolution:
-      { integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /end-of-stream@1.4.4:
-    resolution:
-      { integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q== }
-    dependencies:
-      once: 1.4.0
-    dev: false
-
-  /errno@0.1.8:
-    resolution:
-      { integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A== }
-    hasBin: true
-    dependencies:
-      prr: 1.0.1
-    dev: false
-
   /error-ex@1.3.2:
     resolution:
       { integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g== }
@@ -2330,365 +1061,10 @@ packages:
       is-arrayish: 0.2.1
     dev: false
 
-  /es5-ext@0.10.62:
-    resolution:
-      { integrity: sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA== }
-    engines: { node: ">=0.10" }
-    requiresBuild: true
-    dependencies:
-      es6-iterator: 2.0.3
-      es6-symbol: 3.1.3
-      next-tick: 1.1.0
-    dev: false
-
-  /es6-iterator@2.0.3:
-    resolution:
-      { integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g== }
-    dependencies:
-      d: 1.0.1
-      es5-ext: 0.10.62
-      es6-symbol: 3.1.3
-    dev: false
-
-  /es6-promise@4.2.8:
-    resolution:
-      { integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w== }
-    dev: false
-
-  /es6-symbol@3.1.3:
-    resolution:
-      { integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA== }
-    dependencies:
-      d: 1.0.1
-      ext: 1.7.0
-    dev: false
-
-  /escalade@3.1.1:
-    resolution:
-      { integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw== }
-    engines: { node: ">=6" }
-    dev: false
-
-  /escape-html@1.0.3:
-    resolution:
-      { integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow== }
-    dev: false
-
-  /escape-string-regexp@1.0.2:
-    resolution:
-      { integrity: sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg== }
-    engines: { node: ">=0.8.0" }
-    dev: false
-
   /escape-string-regexp@1.0.5:
     resolution:
       { integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg== }
     engines: { node: ">=0.8.0" }
-    dev: false
-
-  /etag@1.8.1:
-    resolution:
-      { integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /eth-block-tracker@4.4.3(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-A8tG4Z4iNg4mw5tP1Vung9N9IjgMNqpiMoJ/FouSFwNCGHv2X0mmOYwtQOJzki6XN7r7Tyo01S29p7b224I4jw== }
-    dependencies:
-      "@babel/plugin-transform-runtime": 7.23.4(@babel/core@7.23.7)
-      "@babel/runtime": 7.23.5
-      eth-query: 2.1.2
-      json-rpc-random-id: 1.0.1
-      pify: 3.0.0
-      safe-event-emitter: 1.0.1
-    transitivePeerDependencies:
-      - "@babel/core"
-      - supports-color
-    dev: false
-
-  /eth-ens-namehash@2.0.8:
-    resolution:
-      { integrity: sha512-VWEI1+KJfz4Km//dadyvBBoBeSQ0MHTXPvr8UIXiLW6IanxvAV+DmlZAijZwAyggqGUfwQBeHf7tc9wzc1piSw== }
-    dependencies:
-      idna-uts46-hx: 2.3.1
-      js-sha3: 0.5.7
-    dev: false
-
-  /eth-json-rpc-filters@4.2.2:
-    resolution:
-      { integrity: sha512-DGtqpLU7bBg63wPMWg1sCpkKCf57dJ+hj/k3zF26anXMzkmtSBDExL8IhUu7LUd34f0Zsce3PYNO2vV2GaTzaw== }
-    dependencies:
-      "@metamask/safe-event-emitter": 2.0.0
-      async-mutex: 0.2.6
-      eth-json-rpc-middleware: 6.0.0
-      eth-query: 2.1.2
-      json-rpc-engine: 6.1.0
-      pify: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /eth-json-rpc-infura@5.1.0:
-    resolution:
-      { integrity: sha512-THzLye3PHUSGn1EXMhg6WTLW9uim7LQZKeKaeYsS9+wOBcamRiCQVGHa6D2/4P0oS0vSaxsBnU/J6qvn0MPdow== }
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    dependencies:
-      eth-json-rpc-middleware: 6.0.0
-      eth-rpc-errors: 3.0.0
-      json-rpc-engine: 5.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /eth-json-rpc-middleware@6.0.0:
-    resolution:
-      { integrity: sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ== }
-    dependencies:
-      btoa: 1.2.1
-      clone: 2.1.2
-      eth-query: 2.1.2
-      eth-rpc-errors: 3.0.0
-      eth-sig-util: 1.4.2
-      ethereumjs-util: 5.2.1
-      json-rpc-engine: 5.4.0
-      json-stable-stringify: 1.1.0
-      node-fetch: 2.7.0
-      pify: 3.0.0
-      safe-event-emitter: 1.0.1
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /eth-lib@0.1.29:
-    resolution:
-      { integrity: sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ== }
-    dependencies:
-      bn.js: 4.12.0
-      elliptic: 6.5.4
-      nano-json-stream-parser: 0.1.2
-      servify: 0.1.12
-      ws: 3.3.3
-      xhr-request-promise: 0.1.3
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /eth-lib@0.2.8:
-    resolution:
-      { integrity: sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw== }
-    dependencies:
-      bn.js: 4.12.0
-      elliptic: 6.5.4
-      xhr-request-promise: 0.1.3
-    dev: false
-
-  /eth-query@2.1.2:
-    resolution:
-      { integrity: sha512-srES0ZcvwkR/wd5OQBRA1bIJMww1skfGS0s8wlwK3/oNP4+wnds60krvu5R1QbpRQjMmpG5OMIWro5s7gvDPsA== }
-    dependencies:
-      json-rpc-random-id: 1.0.1
-      xtend: 4.0.2
-    dev: false
-
-  /eth-rpc-errors@3.0.0:
-    resolution:
-      { integrity: sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg== }
-    dependencies:
-      fast-safe-stringify: 2.1.1
-    dev: false
-
-  /eth-rpc-errors@4.0.3:
-    resolution:
-      { integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg== }
-    dependencies:
-      fast-safe-stringify: 2.1.1
-    dev: false
-
-  /eth-sig-util@1.4.2:
-    resolution:
-      { integrity: sha512-iNZ576iTOGcfllftB73cPB5AN+XUQAT/T8xzsILsghXC1o8gJUqe3RHlcDqagu+biFpYQ61KQrZZJza8eRSYqw== }
-    deprecated: Deprecated in favor of '@metamask/eth-sig-util'
-    dependencies:
-      ethereumjs-abi: github.com/ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0
-      ethereumjs-util: 5.2.1
-    dev: false
-
-  /ethereum-bloom-filters@1.0.10:
-    resolution:
-      { integrity: sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA== }
-    dependencies:
-      js-sha3: 0.8.0
-    dev: false
-
-  /ethereum-common@0.0.18:
-    resolution:
-      { integrity: sha512-EoltVQTRNg2Uy4o84qpa2aXymXDJhxm7eos/ACOg0DG4baAbMjhbdAEsx9GeE8sC3XCxnYvrrzZDH8D8MtA2iQ== }
-    dev: false
-
-  /ethereum-common@0.2.0:
-    resolution:
-      { integrity: sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA== }
-    dev: false
-
-  /ethereum-cryptography@0.1.3:
-    resolution:
-      { integrity: sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ== }
-    dependencies:
-      "@types/pbkdf2": 3.1.2
-      "@types/secp256k1": 4.0.6
-      blakejs: 1.2.1
-      browserify-aes: 1.2.0
-      bs58check: 2.1.2
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      hash.js: 1.1.7
-      keccak: 3.0.4
-      pbkdf2: 3.1.2
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-      scrypt-js: 3.0.1
-      secp256k1: 4.0.3
-      setimmediate: 1.0.5
-    dev: false
-
-  /ethereum-cryptography@1.1.2:
-    resolution:
-      { integrity: sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ== }
-    dependencies:
-      "@noble/hashes": 1.1.2
-      "@noble/secp256k1": 1.6.3
-      "@scure/bip32": 1.1.0
-      "@scure/bip39": 1.1.0
-    dev: false
-
-  /ethereum-protocol@1.0.1:
-    resolution:
-      { integrity: sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg== }
-    dev: false
-
-  /ethereumjs-abi@0.6.8:
-    resolution:
-      { integrity: sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA== }
-    dependencies:
-      bn.js: 4.12.0
-      ethereumjs-util: 6.2.1
-    dev: false
-
-  /ethereumjs-account@2.0.5:
-    resolution:
-      { integrity: sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA== }
-    dependencies:
-      ethereumjs-util: 5.2.1
-      rlp: 2.2.7
-      safe-buffer: 5.2.1
-    dev: false
-
-  /ethereumjs-block@1.7.1:
-    resolution:
-      { integrity: sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg== }
-    deprecated: "New package name format for new versions: @ethereumjs/block. Please update."
-    dependencies:
-      async: 2.6.4
-      ethereum-common: 0.2.0
-      ethereumjs-tx: 1.3.7
-      ethereumjs-util: 5.2.1
-      merkle-patricia-tree: 2.3.2
-    dev: false
-
-  /ethereumjs-block@2.2.2:
-    resolution:
-      { integrity: sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg== }
-    deprecated: "New package name format for new versions: @ethereumjs/block. Please update."
-    dependencies:
-      async: 2.6.4
-      ethereumjs-common: 1.5.2
-      ethereumjs-tx: 2.1.2
-      ethereumjs-util: 5.2.1
-      merkle-patricia-tree: 2.3.2
-    dev: false
-
-  /ethereumjs-common@1.5.2:
-    resolution:
-      { integrity: sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA== }
-    deprecated: "New package name format for new versions: @ethereumjs/common. Please update."
-    dev: false
-
-  /ethereumjs-tx@1.3.7:
-    resolution:
-      { integrity: sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA== }
-    deprecated: "New package name format for new versions: @ethereumjs/tx. Please update."
-    dependencies:
-      ethereum-common: 0.0.18
-      ethereumjs-util: 5.2.1
-    dev: false
-
-  /ethereumjs-tx@2.1.2:
-    resolution:
-      { integrity: sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw== }
-    deprecated: "New package name format for new versions: @ethereumjs/tx. Please update."
-    dependencies:
-      ethereumjs-common: 1.5.2
-      ethereumjs-util: 6.2.1
-    dev: false
-
-  /ethereumjs-util@5.2.1:
-    resolution:
-      { integrity: sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ== }
-    dependencies:
-      bn.js: 4.12.0
-      create-hash: 1.2.0
-      elliptic: 6.5.4
-      ethereum-cryptography: 0.1.3
-      ethjs-util: 0.1.6
-      rlp: 2.2.7
-      safe-buffer: 5.2.1
-    dev: false
-
-  /ethereumjs-util@6.2.1:
-    resolution:
-      { integrity: sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw== }
-    dependencies:
-      "@types/bn.js": 4.11.6
-      bn.js: 4.12.0
-      create-hash: 1.2.0
-      elliptic: 6.5.4
-      ethereum-cryptography: 0.1.3
-      ethjs-util: 0.1.6
-      rlp: 2.2.7
-    dev: false
-
-  /ethereumjs-util@7.1.5:
-    resolution:
-      { integrity: sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg== }
-    engines: { node: ">=10.0.0" }
-    dependencies:
-      "@types/bn.js": 5.1.5
-      bn.js: 5.2.1
-      create-hash: 1.2.0
-      ethereum-cryptography: 0.1.3
-      rlp: 2.2.7
-    dev: false
-
-  /ethereumjs-vm@2.6.0:
-    resolution:
-      { integrity: sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw== }
-    deprecated: "New package name format for new versions: @ethereumjs/vm. Please update."
-    dependencies:
-      async: 2.6.4
-      async-eventemitter: 0.2.4
-      ethereumjs-account: 2.0.5
-      ethereumjs-block: 2.2.2
-      ethereumjs-common: 1.5.2
-      ethereumjs-util: 6.2.1
-      fake-merkle-patricia-tree: 1.0.1
-      functional-red-black-tree: 1.0.1
-      merkle-patricia-tree: 2.3.2
-      rustbn.js: 0.2.0
-      safe-buffer: 5.2.1
     dev: false
 
   /ethers@5.7.2:
@@ -2730,46 +1106,9 @@ packages:
       - utf-8-validate
     dev: false
 
-  /ethjs-unit@0.1.6:
-    resolution:
-      { integrity: sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw== }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-    dependencies:
-      bn.js: 4.11.6
-      number-to-bn: 1.7.0
-    dev: false
-
-  /ethjs-util@0.1.6:
-    resolution:
-      { integrity: sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w== }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-    dependencies:
-      is-hex-prefixed: 1.0.0
-      strip-hex-prefix: 1.0.0
-    dev: false
-
-  /eventemitter3@4.0.4:
-    resolution:
-      { integrity: sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ== }
-    dev: false
-
   /eventemitter3@5.0.1:
     resolution:
       { integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA== }
-    dev: false
-
-  /events@3.3.0:
-    resolution:
-      { integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q== }
-    engines: { node: ">=0.8.x" }
-    dev: false
-
-  /evp_bytestokey@1.0.3:
-    resolution:
-      { integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA== }
-    dependencies:
-      md5.js: 1.3.5
-      safe-buffer: 5.2.1
     dev: false
 
   /execa@7.2.0:
@@ -2782,75 +1121,10 @@ packages:
       human-signals: 4.3.1
       is-stream: 3.0.0
       merge-stream: 2.0.0
-      npm-run-path: 5.1.0
+      npm-run-path: 5.2.0
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
-    dev: false
-
-  /express@4.18.2:
-    resolution:
-      { integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ== }
-    engines: { node: ">= 0.10.0" }
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.1
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.5.0
-      cookie-signature: 1.0.6
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.2.0
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      merge-descriptors: 1.0.1
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.7
-      proxy-addr: 2.0.7
-      qs: 6.11.0
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.18.0
-      serve-static: 1.15.0
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /ext@1.7.0:
-    resolution:
-      { integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw== }
-    dependencies:
-      type: 2.7.2
-    dev: false
-
-  /extend@3.0.2:
-    resolution:
-      { integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g== }
-    dev: false
-
-  /extsprintf@1.3.0:
-    resolution:
-      { integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g== }
-    engines: { "0": node >=0.6.0 }
-    dev: false
-
-  /fake-merkle-patricia-tree@1.0.1:
-    resolution:
-      { integrity: sha512-Tgq37lkc9pUIgIKw5uitNUKcgcYL3R6JvXtKQbOf/ZSavXbidsksgp/pAY6p//uhw0I4yoMsvTSovvVIsk/qxA== }
-    dependencies:
-      checkpoint-store: 1.1.0
     dev: false
 
   /fast-deep-equal@3.1.3:
@@ -2868,11 +1142,6 @@ packages:
       { integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw== }
     dev: false
 
-  /fast-safe-stringify@2.1.1:
-    resolution:
-      { integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA== }
-    dev: false
-
   /fill-range@7.0.1:
     resolution:
       { integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ== }
@@ -2881,47 +1150,15 @@ packages:
       to-regex-range: 5.0.1
     dev: false
 
-  /finalhandler@1.2.0:
+  /follow-redirects@1.15.5:
     resolution:
-      { integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.1
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /find-up@1.1.2:
-    resolution:
-      { integrity: sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      path-exists: 2.1.0
-      pinkie-promise: 2.0.1
-    dev: false
-
-  /follow-redirects@1.15.3:
-    resolution:
-      { integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q== }
+      { integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw== }
     engines: { node: ">=4.0" }
     peerDependencies:
       debug: "*"
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
-
-  /for-each@0.3.3:
-    resolution:
-      { integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw== }
-    dependencies:
-      is-callable: 1.2.7
     dev: false
 
   /foreground-child@3.1.1:
@@ -2933,36 +1170,9 @@ packages:
       signal-exit: 4.1.0
     dev: true
 
-  /forever-agent@0.6.1:
+  /forge-std@1.1.2:
     resolution:
-      { integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw== }
-    dev: false
-
-  /form-data-encoder@1.7.1:
-    resolution:
-      { integrity: sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg== }
-    dev: false
-
-  /form-data@2.3.3:
-    resolution:
-      { integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ== }
-    engines: { node: ">= 0.12" }
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
-
-  /forwarded@0.2.0:
-    resolution:
-      { integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /fresh@0.5.2:
-    resolution:
-      { integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q== }
-    engines: { node: ">= 0.6" }
+      { integrity: sha512-Wfb0iAS9PcfjMKtGpWQw9mXzJxrWD62kJCUqqLcyuI0+VRtJ3j20XembjF3kS20qELYdXft1vD/SPFVWVKMFOw== }
     dev: false
 
   /fs-extra@11.2.0:
@@ -2975,55 +1185,9 @@ packages:
       universalify: 2.0.1
     dev: false
 
-  /fs-extra@4.0.3:
-    resolution:
-      { integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg== }
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-    dev: false
-
-  /fs-minipass@1.2.7:
-    resolution:
-      { integrity: sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA== }
-    dependencies:
-      minipass: 2.9.0
-    dev: false
-
   /fs.realpath@1.0.0:
     resolution:
       { integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw== }
-    dev: false
-
-  /fsevents@2.3.3:
-    resolution:
-      { integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw== }
-    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /function-bind@1.1.2:
-    resolution:
-      { integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA== }
-    dev: false
-
-  /functional-red-black-tree@1.0.1:
-    resolution:
-      { integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g== }
-    dev: false
-
-  /gensync@1.0.0-beta.2:
-    resolution:
-      { integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg== }
-    engines: { node: ">=6.9.0" }
-    dev: false
-
-  /get-caller-file@1.0.3:
-    resolution:
-      { integrity: sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w== }
     dev: false
 
   /get-func-name@2.0.2:
@@ -3031,43 +1195,10 @@ packages:
       { integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ== }
     dev: false
 
-  /get-intrinsic@1.2.2:
-    resolution:
-      { integrity: sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA== }
-    dependencies:
-      function-bind: 1.1.2
-      has-proto: 1.0.1
-      has-symbols: 1.0.3
-      hasown: 2.0.0
-    dev: false
-
-  /get-stream@5.2.0:
-    resolution:
-      { integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA== }
-    engines: { node: ">=8" }
-    dependencies:
-      pump: 3.0.0
-    dev: false
-
   /get-stream@6.0.1:
     resolution:
       { integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg== }
     engines: { node: ">=10" }
-    dev: false
-
-  /getpass@0.1.7:
-    resolution:
-      { integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng== }
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
-
-  /glob-parent@5.1.2:
-    resolution:
-      { integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow== }
-    engines: { node: ">= 6" }
-    dependencies:
-      is-glob: 4.0.3
     dev: false
 
   /glob@10.3.10:
@@ -3083,14 +1214,6 @@ packages:
       path-scurry: 1.10.1
     dev: true
 
-  /glob@3.2.11:
-    resolution:
-      { integrity: sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g== }
-    dependencies:
-      inherits: 2.0.4
-      minimatch: 0.3.0
-    dev: false
-
   /glob@8.1.0:
     resolution:
       { integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ== }
@@ -3103,89 +1226,9 @@ packages:
       once: 1.4.0
     dev: false
 
-  /global@4.4.0:
-    resolution:
-      { integrity: sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w== }
-    dependencies:
-      min-document: 2.19.0
-      process: 0.11.10
-    dev: false
-
-  /globals@11.12.0:
-    resolution:
-      { integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA== }
-    engines: { node: ">=4" }
-    dev: false
-
-  /gopd@1.0.1:
-    resolution:
-      { integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA== }
-    dependencies:
-      get-intrinsic: 1.2.2
-    dev: false
-
-  /got@11.8.6:
-    resolution:
-      { integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g== }
-    engines: { node: ">=10.19.0" }
-    dependencies:
-      "@sindresorhus/is": 4.6.0
-      "@szmarczak/http-timer": 4.0.6
-      "@types/cacheable-request": 6.0.3
-      "@types/responselike": 1.0.3
-      cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
-      decompress-response: 6.0.0
-      http2-wrapper: 1.0.3
-      lowercase-keys: 2.0.0
-      p-cancelable: 2.1.1
-      responselike: 2.0.1
-    dev: false
-
-  /got@12.1.0:
-    resolution:
-      { integrity: sha512-hBv2ty9QN2RdbJJMK3hesmSkFTjVIHyIDDbssCKnSmq62edGgImJWD10Eb1k77TiV1bxloxqcFAVK8+9pkhOig== }
-    engines: { node: ">=14.16" }
-    dependencies:
-      "@sindresorhus/is": 4.6.0
-      "@szmarczak/http-timer": 5.0.1
-      "@types/cacheable-request": 6.0.3
-      "@types/responselike": 1.0.3
-      cacheable-lookup: 6.1.0
-      cacheable-request: 7.0.4
-      decompress-response: 6.0.0
-      form-data-encoder: 1.7.1
-      get-stream: 6.0.1
-      http2-wrapper: 2.2.1
-      lowercase-keys: 3.0.0
-      p-cancelable: 3.0.0
-      responselike: 2.0.1
-    dev: false
-
   /graceful-fs@4.2.11:
     resolution:
       { integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ== }
-    dev: false
-
-  /growl@1.9.2:
-    resolution:
-      { integrity: sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw== }
-    dev: false
-
-  /har-schema@2.0.0:
-    resolution:
-      { integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q== }
-    engines: { node: ">=4" }
-    dev: false
-
-  /har-validator@5.1.5:
-    resolution:
-      { integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w== }
-    engines: { node: ">=6" }
-    deprecated: this library is no longer supported
-    dependencies:
-      ajv: 6.12.6
-      har-schema: 2.0.0
     dev: false
 
   /has-flag@3.0.0:
@@ -3200,57 +1243,12 @@ packages:
     engines: { node: ">=8" }
     dev: false
 
-  /has-property-descriptors@1.0.1:
-    resolution:
-      { integrity: sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg== }
-    dependencies:
-      get-intrinsic: 1.2.2
-    dev: false
-
-  /has-proto@1.0.1:
-    resolution:
-      { integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /has-symbols@1.0.3:
-    resolution:
-      { integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /has-tostringtag@1.0.0:
-    resolution:
-      { integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      has-symbols: 1.0.3
-    dev: false
-
-  /hash-base@3.1.0:
-    resolution:
-      { integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA== }
-    engines: { node: ">=4" }
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      safe-buffer: 5.2.1
-    dev: false
-
   /hash.js@1.1.7:
     resolution:
       { integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA== }
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-    dev: false
-
-  /hasown@2.0.0:
-    resolution:
-      { integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      function-bind: 1.1.2
     dev: false
 
   /header-case@2.0.4:
@@ -3270,61 +1268,6 @@ packages:
       minimalistic-crypto-utils: 1.0.1
     dev: false
 
-  /hosted-git-info@2.8.9:
-    resolution:
-      { integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw== }
-    dev: false
-
-  /http-cache-semantics@4.1.1:
-    resolution:
-      { integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ== }
-    dev: false
-
-  /http-errors@2.0.0:
-    resolution:
-      { integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.1
-      toidentifier: 1.0.1
-    dev: false
-
-  /http-https@1.0.0:
-    resolution:
-      { integrity: sha512-o0PWwVCSp3O0wS6FvNr6xfBCHgt0m1tvPLFOCc2iFDKTRAXhB7m8klDf7ErowFH8POa6dVdGatKU5I1YYwzUyg== }
-    dev: false
-
-  /http-signature@1.2.0:
-    resolution:
-      { integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ== }
-    engines: { node: ">=0.8", npm: ">=1.3.7" }
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.18.0
-    dev: false
-
-  /http2-wrapper@1.0.3:
-    resolution:
-      { integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg== }
-    engines: { node: ">=10.19.0" }
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
-    dev: false
-
-  /http2-wrapper@2.2.1:
-    resolution:
-      { integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ== }
-    engines: { node: ">=10.19.0" }
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
-    dev: false
-
   /human-signals@4.3.1:
     resolution:
       { integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ== }
@@ -3338,41 +1281,10 @@ packages:
     hasBin: true
     dev: false
 
-  /iconv-lite@0.4.24:
-    resolution:
-      { integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
-  /idna-uts46-hx@2.3.1:
-    resolution:
-      { integrity: sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA== }
-    engines: { node: ">=4.0.0" }
-    dependencies:
-      punycode: 2.1.0
-    dev: false
-
-  /ieee754@1.2.1:
-    resolution:
-      { integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA== }
-    dev: false
-
-  /ignore-by-default@1.0.1:
-    resolution:
-      { integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA== }
-    dev: false
-
   /ignore@5.3.0:
     resolution:
       { integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg== }
     engines: { node: ">= 4" }
-    dev: false
-
-  /immediate@3.3.0:
-    resolution:
-      { integrity: sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q== }
     dev: false
 
   /import-fresh@3.3.0:
@@ -3397,71 +1309,9 @@ packages:
       { integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ== }
     dev: false
 
-  /invert-kv@1.0.0:
-    resolution:
-      { integrity: sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /ipaddr.js@1.9.1:
-    resolution:
-      { integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g== }
-    engines: { node: ">= 0.10" }
-    dev: false
-
-  /is-arguments@1.1.1:
-    resolution:
-      { integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      call-bind: 1.0.5
-      has-tostringtag: 1.0.0
-    dev: false
-
   /is-arrayish@0.2.1:
     resolution:
       { integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg== }
-    dev: false
-
-  /is-binary-path@2.1.0:
-    resolution:
-      { integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw== }
-    engines: { node: ">=8" }
-    dependencies:
-      binary-extensions: 2.2.0
-    dev: false
-
-  /is-callable@1.2.7:
-    resolution:
-      { integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /is-core-module@2.13.1:
-    resolution:
-      { integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw== }
-    dependencies:
-      hasown: 2.0.0
-    dev: false
-
-  /is-extglob@2.1.1:
-    resolution:
-      { integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /is-fn@1.0.0:
-    resolution:
-      { integrity: sha512-XoFPJQmsAShb3jEQRfzf2rqXavq7fIqF/jOekp308JlThqrODnMpweVSGilKTCXELfLhltGP2AGgbQGVP8F1dg== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /is-fullwidth-code-point@1.0.0:
-    resolution:
-      { integrity: sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      number-is-nan: 1.0.1
     dev: false
 
   /is-fullwidth-code-point@3.0.0:
@@ -3473,33 +1323,6 @@ packages:
     resolution:
       { integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ== }
     engines: { node: ">=12" }
-    dev: false
-
-  /is-function@1.0.2:
-    resolution:
-      { integrity: sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ== }
-    dev: false
-
-  /is-generator-function@1.0.10:
-    resolution:
-      { integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      has-tostringtag: 1.0.0
-    dev: false
-
-  /is-glob@4.0.3:
-    resolution:
-      { integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      is-extglob: 2.1.1
-    dev: false
-
-  /is-hex-prefixed@1.0.0:
-    resolution:
-      { integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA== }
-    engines: { node: ">=6.5.0", npm: ">=3" }
     dev: false
 
   /is-number@7.0.0:
@@ -3514,47 +1337,9 @@ packages:
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     dev: false
 
-  /is-typed-array@1.1.12:
-    resolution:
-      { integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      which-typed-array: 1.1.13
-    dev: false
-
-  /is-typedarray@1.0.0:
-    resolution:
-      { integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA== }
-    dev: false
-
-  /is-utf8@0.2.1:
-    resolution:
-      { integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q== }
-    dev: false
-
-  /isarray@0.0.1:
-    resolution:
-      { integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ== }
-    dev: false
-
-  /isarray@1.0.0:
-    resolution:
-      { integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ== }
-    dev: false
-
-  /isarray@2.0.5:
-    resolution:
-      { integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw== }
-    dev: false
-
   /isexe@2.0.0:
     resolution:
       { integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw== }
-
-  /isstream@0.1.2:
-    resolution:
-      { integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g== }
-    dev: false
 
   /jackspeak@2.3.6:
     resolution:
@@ -3565,21 +1350,6 @@ packages:
     optionalDependencies:
       "@pkgjs/parseargs": 0.11.0
     dev: true
-
-  /jade@0.26.3:
-    resolution:
-      { integrity: sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A== }
-    deprecated: Jade has been renamed to pug, please install the latest version of pug instead of jade
-    hasBin: true
-    dependencies:
-      commander: 0.6.1
-      mkdirp: 0.3.0
-    dev: false
-
-  /js-sha3@0.5.7:
-    resolution:
-      { integrity: sha512-GII20kjaPX0zJ8wzkTbNDYMY7msuZcTWk8S5UOh6806Jq/wz1J8/bnr8uGU0DAUmYDjj2Mr4X1cW8v/GLYnR+g== }
-    dev: false
 
   /js-sha3@0.8.0:
     resolution:
@@ -3599,48 +1369,9 @@ packages:
       argparse: 2.0.1
     dev: false
 
-  /jsbn@0.1.1:
-    resolution:
-      { integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg== }
-    dev: false
-
-  /jsesc@2.5.2:
-    resolution:
-      { integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA== }
-    engines: { node: ">=4" }
-    hasBin: true
-    dev: false
-
-  /json-buffer@3.0.1:
-    resolution:
-      { integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ== }
-    dev: false
-
   /json-parse-even-better-errors@2.3.1:
     resolution:
       { integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w== }
-    dev: false
-
-  /json-rpc-engine@5.4.0:
-    resolution:
-      { integrity: sha512-rAffKbPoNDjuRnXkecTjnsE3xLLrb00rEkdgalINhaYVYIxDwWtvYBr9UFbhTvPB1B2qUOLoFd/cV6f4Q7mh7g== }
-    dependencies:
-      eth-rpc-errors: 3.0.0
-      safe-event-emitter: 1.0.1
-    dev: false
-
-  /json-rpc-engine@6.1.0:
-    resolution:
-      { integrity: sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ== }
-    engines: { node: ">=10.0.0" }
-    dependencies:
-      "@metamask/safe-event-emitter": 2.0.0
-      eth-rpc-errors: 4.0.3
-    dev: false
-
-  /json-rpc-random-id@1.0.1:
-    resolution:
-      { integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA== }
     dev: false
 
   /json-schema-traverse@0.4.1:
@@ -3653,41 +1384,6 @@ packages:
       { integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug== }
     dev: false
 
-  /json-schema@0.4.0:
-    resolution:
-      { integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA== }
-    dev: false
-
-  /json-stable-stringify@1.1.0:
-    resolution:
-      { integrity: sha512-zfA+5SuwYN2VWqN1/5HZaDzQKLJHaBVMZIIM+wuYjdptkaQsqzDdqjqf+lZZJUuJq1aanHiY8LhH8LmH+qBYJA== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      call-bind: 1.0.5
-      isarray: 2.0.5
-      jsonify: 0.0.1
-      object-keys: 1.1.1
-    dev: false
-
-  /json-stringify-safe@5.0.1:
-    resolution:
-      { integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA== }
-    dev: false
-
-  /json5@2.2.3:
-    resolution:
-      { integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg== }
-    engines: { node: ">=6" }
-    hasBin: true
-    dev: false
-
-  /jsonfile@4.0.0:
-    resolution:
-      { integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg== }
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    dev: false
-
   /jsonfile@6.1.0:
     resolution:
       { integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ== }
@@ -3695,102 +1391,6 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: false
-
-  /jsonify@0.0.1:
-    resolution:
-      { integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg== }
-    dev: false
-
-  /jsprim@1.4.2:
-    resolution:
-      { integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw== }
-    engines: { node: ">=0.6.0" }
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
-    dev: false
-
-  /keccak@3.0.2:
-    resolution:
-      { integrity: sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ== }
-    engines: { node: ">=10.0.0" }
-    requiresBuild: true
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.7.1
-      readable-stream: 3.6.2
-    dev: false
-
-  /keccak@3.0.4:
-    resolution:
-      { integrity: sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q== }
-    engines: { node: ">=10.0.0" }
-    requiresBuild: true
-    dependencies:
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.7.1
-      readable-stream: 3.6.2
-    dev: false
-
-  /keyv@4.5.4:
-    resolution:
-      { integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw== }
-    dependencies:
-      json-buffer: 3.0.1
-    dev: false
-
-  /lcid@1.0.0:
-    resolution:
-      { integrity: sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      invert-kv: 1.0.0
-    dev: false
-
-  /level-codec@7.0.1:
-    resolution:
-      { integrity: sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ== }
-    dev: false
-
-  /level-errors@1.0.5:
-    resolution:
-      { integrity: sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig== }
-    dependencies:
-      errno: 0.1.8
-    dev: false
-
-  /level-iterator-stream@1.3.1:
-    resolution:
-      { integrity: sha512-1qua0RHNtr4nrZBgYlpV0qHHeHpcRRWTxEZJ8xsemoHAXNL5tbooh4tPEEqIqsbWCAJBmUmkwYK/sW5OrFjWWw== }
-    dependencies:
-      inherits: 2.0.4
-      level-errors: 1.0.5
-      readable-stream: 1.1.14
-      xtend: 4.0.2
-    dev: false
-
-  /level-ws@0.0.0:
-    resolution:
-      { integrity: sha512-XUTaO/+Db51Uiyp/t7fCMGVFOTdtLS/NIACxE/GHsij15mKzxksZifKVjlXDF41JMUP/oM1Oc4YNGdKnc3dVLw== }
-    dependencies:
-      readable-stream: 1.0.34
-      xtend: 2.1.2
-    dev: false
-
-  /levelup@1.3.9:
-    resolution:
-      { integrity: sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ== }
-    dependencies:
-      deferred-leveldown: 1.2.2
-      level-codec: 7.0.1
-      level-errors: 1.0.5
-      level-iterator-stream: 1.3.1
-      prr: 1.0.1
-      semver: 5.4.1
-      xtend: 4.0.2
     dev: false
 
   /lilconfig@2.1.0:
@@ -3812,7 +1412,7 @@ packages:
     dependencies:
       chalk: 5.3.0
       commander: 11.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       execa: 7.2.0
       lilconfig: 2.1.0
       listr2: 6.6.1
@@ -3841,28 +1441,6 @@ packages:
       log-update: 5.0.1
       rfdc: 1.3.0
       wrap-ansi: 8.1.0
-    dev: false
-
-  /load-json-file@1.1.0:
-    resolution:
-      { integrity: sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      graceful-fs: 4.2.11
-      parse-json: 2.2.0
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-      strip-bom: 2.0.0
-    dev: false
-
-  /lodash.assign@4.2.0:
-    resolution:
-      { integrity: sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw== }
-    dev: false
-
-  /lodash.debounce@4.0.8:
-    resolution:
-      { integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow== }
     dev: false
 
   /lodash.truncate@4.4.2:
@@ -3901,35 +1479,11 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /lowercase-keys@2.0.0:
-    resolution:
-      { integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA== }
-    engines: { node: ">=8" }
-    dev: false
-
-  /lowercase-keys@3.0.0:
-    resolution:
-      { integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ== }
-    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-    dev: false
-
   /lru-cache@10.1.0:
     resolution:
       { integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag== }
     engines: { node: 14 || >=16.14 }
     dev: true
-
-  /lru-cache@2.7.3:
-    resolution:
-      { integrity: sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ== }
-    dev: false
-
-  /lru-cache@5.1.1:
-    resolution:
-      { integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w== }
-    dependencies:
-      yallist: 3.1.1
-    dev: false
 
   /lru-cache@6.0.0:
     resolution:
@@ -3939,41 +1493,9 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /ltgt@2.2.1:
-    resolution:
-      { integrity: sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA== }
-    dev: false
-
   /make-error@1.3.6:
     resolution:
       { integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw== }
-    dev: false
-
-  /md5.js@1.3.5:
-    resolution:
-      { integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg== }
-    dependencies:
-      hash-base: 3.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-    dev: false
-
-  /media-typer@0.3.0:
-    resolution:
-      { integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /memdown@1.4.1:
-    resolution:
-      { integrity: sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w== }
-    dependencies:
-      abstract-leveldown: 2.7.2
-      functional-red-black-tree: 1.0.1
-      immediate: 3.3.0
-      inherits: 2.0.4
-      ltgt: 2.2.1
-      safe-buffer: 5.1.2
     dev: false
 
   /memorystream@0.3.1:
@@ -3982,34 +1504,9 @@ packages:
     engines: { node: ">= 0.10.0" }
     dev: false
 
-  /merge-descriptors@1.0.1:
-    resolution:
-      { integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w== }
-    dev: false
-
   /merge-stream@2.0.0:
     resolution:
       { integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w== }
-    dev: false
-
-  /merkle-patricia-tree@2.3.2:
-    resolution:
-      { integrity: sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g== }
-    dependencies:
-      async: 1.5.2
-      ethereumjs-util: 5.2.1
-      level-ws: 0.0.0
-      levelup: 1.3.9
-      memdown: 1.4.1
-      readable-stream: 2.3.8
-      rlp: 2.2.7
-      semaphore: 1.1.0
-    dev: false
-
-  /methods@1.1.2:
-    resolution:
-      { integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w== }
-    engines: { node: ">= 0.6" }
     dev: false
 
   /micromatch@4.0.5:
@@ -4019,27 +1516,6 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
-    dev: false
-
-  /mime-db@1.52.0:
-    resolution:
-      { integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /mime-types@2.1.35:
-    resolution:
-      { integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw== }
-    engines: { node: ">= 0.6" }
-    dependencies:
-      mime-db: 1.52.0
-    dev: false
-
-  /mime@1.6.0:
-    resolution:
-      { integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg== }
-    engines: { node: ">=4" }
-    hasBin: true
     dev: false
 
   /mimic-fn@2.1.0:
@@ -4054,25 +1530,6 @@ packages:
     engines: { node: ">=12" }
     dev: false
 
-  /mimic-response@1.0.1:
-    resolution:
-      { integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ== }
-    engines: { node: ">=4" }
-    dev: false
-
-  /mimic-response@3.1.0:
-    resolution:
-      { integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ== }
-    engines: { node: ">=10" }
-    dev: false
-
-  /min-document@2.19.0:
-    resolution:
-      { integrity: sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ== }
-    dependencies:
-      dom-walk: 0.1.2
-    dev: false
-
   /minimalistic-assert@1.0.1:
     resolution:
       { integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A== }
@@ -4081,22 +1538,6 @@ packages:
   /minimalistic-crypto-utils@1.0.1:
     resolution:
       { integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg== }
-    dev: false
-
-  /minimatch@0.3.0:
-    resolution:
-      { integrity: sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA== }
-    deprecated: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
-    dependencies:
-      lru-cache: 2.7.3
-      sigmund: 1.0.1
-    dev: false
-
-  /minimatch@3.1.2:
-    resolution:
-      { integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw== }
-    dependencies:
-      brace-expansion: 1.1.11
     dev: false
 
   /minimatch@5.1.6:
@@ -4115,161 +1556,15 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /minimist@0.0.8:
-    resolution:
-      { integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q== }
-    dev: false
-
-  /minimist@1.2.8:
-    resolution:
-      { integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA== }
-    dev: false
-
-  /minipass@2.9.0:
-    resolution:
-      { integrity: sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg== }
-    dependencies:
-      safe-buffer: 5.2.1
-      yallist: 3.1.1
-    dev: false
-
   /minipass@7.0.4:
     resolution:
       { integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ== }
     engines: { node: ">=16 || 14 >=14.17" }
     dev: true
 
-  /minizlib@1.3.3:
-    resolution:
-      { integrity: sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q== }
-    dependencies:
-      minipass: 2.9.0
-    dev: false
-
-  /mkdirp-promise@5.0.1:
-    resolution:
-      { integrity: sha512-Hepn5kb1lJPtVW84RFT40YG1OddBNTOVUZR2bzQUHc+Z03en8/3uX0+060JDhcEzyO08HmipsN9DcnFMxhIL9w== }
-    engines: { node: ">=4" }
-    deprecated: This package is broken and no longer maintained. 'mkdirp' itself supports promises now, please switch to that.
-    dependencies:
-      mkdirp: 3.0.1
-    dev: false
-
-  /mkdirp@0.3.0:
-    resolution:
-      { integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew== }
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    dev: false
-
-  /mkdirp@0.5.1:
-    resolution:
-      { integrity: sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA== }
-    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
-    hasBin: true
-    dependencies:
-      minimist: 0.0.8
-    dev: false
-
-  /mkdirp@0.5.6:
-    resolution:
-      { integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw== }
-    hasBin: true
-    dependencies:
-      minimist: 1.2.8
-    dev: false
-
-  /mkdirp@3.0.1:
-    resolution:
-      { integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg== }
-    engines: { node: ">=10" }
-    hasBin: true
-    dev: false
-
-  /mocha@2.5.3:
-    resolution:
-      { integrity: sha512-jNt2iEk9FPmZLzL+sm4FNyOIDYXf2wUU6L4Cc8OIKK/kzgMHKPi4YhTZqG4bW4kQVdIv6wutDybRhXfdnujA1Q== }
-    engines: { node: ">= 0.8.x" }
-    hasBin: true
-    dependencies:
-      commander: 2.3.0
-      debug: 2.2.0(supports-color@1.2.0)
-      diff: 1.4.0
-      escape-string-regexp: 1.0.2
-      glob: 3.2.11
-      growl: 1.9.2
-      jade: 0.26.3
-      mkdirp: 0.5.1
-      supports-color: 1.2.0
-      to-iso-string: 0.0.2
-    dev: false
-
-  /mock-fs@4.14.0:
-    resolution:
-      { integrity: sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw== }
-    dev: false
-
-  /ms@0.7.1:
-    resolution:
-      { integrity: sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg== }
-    dev: false
-
-  /ms@2.0.0:
-    resolution:
-      { integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A== }
-    dev: false
-
   /ms@2.1.2:
     resolution:
       { integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w== }
-    dev: false
-
-  /ms@2.1.3:
-    resolution:
-      { integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA== }
-    dev: false
-
-  /multibase@0.6.1:
-    resolution:
-      { integrity: sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw== }
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      base-x: 3.0.9
-      buffer: 5.7.1
-    dev: false
-
-  /multibase@0.7.0:
-    resolution:
-      { integrity: sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg== }
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      base-x: 3.0.9
-      buffer: 5.7.1
-    dev: false
-
-  /multicodec@0.5.7:
-    resolution:
-      { integrity: sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA== }
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      varint: 5.0.2
-    dev: false
-
-  /multicodec@1.0.4:
-    resolution:
-      { integrity: sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg== }
-    deprecated: This module has been superseded by the multiformats module
-    dependencies:
-      buffer: 5.7.1
-      varint: 5.0.2
-    dev: false
-
-  /multihashes@0.4.21:
-    resolution:
-      { integrity: sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw== }
-    dependencies:
-      buffer: 5.7.1
-      multibase: 0.7.0
-      varint: 5.0.2
     dev: false
 
   /n@9.2.0:
@@ -4277,22 +1572,6 @@ packages:
       { integrity: sha512-R8mFN2OWwNVc+r1f9fDzcT34DnDwUIHskrpTesZ6SdluaXBBnRtTu5tlfaSPloBi1Z/eGJoPO9nhyawWPad5UQ== }
     os: ["!win32"]
     hasBin: true
-    dev: false
-
-  /nano-json-stream-parser@0.1.2:
-    resolution:
-      { integrity: sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew== }
-    dev: false
-
-  /negotiator@0.6.3:
-    resolution:
-      { integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /next-tick@1.1.0:
-    resolution:
-      { integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ== }
     dev: false
 
   /no-case@3.0.4:
@@ -4303,146 +1582,12 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /node-addon-api@2.0.2:
+  /npm-run-path@5.2.0:
     resolution:
-      { integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA== }
-    dev: false
-
-  /node-fetch@2.7.0:
-    resolution:
-      { integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A== }
-    engines: { node: 4.x || >=6.0.0 }
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: false
-
-  /node-gyp-build@4.7.1:
-    resolution:
-      { integrity: sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg== }
-    hasBin: true
-    dev: false
-
-  /node-releases@2.0.14:
-    resolution:
-      { integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw== }
-    dev: false
-
-  /nodemon@3.0.2:
-    resolution:
-      { integrity: sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA== }
-    engines: { node: ">=10" }
-    hasBin: true
-    dependencies:
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@5.5.0)
-      ignore-by-default: 1.0.1
-      minimatch: 3.1.2
-      pstree.remy: 1.1.8
-      semver: 7.5.4
-      simple-update-notifier: 2.0.0
-      supports-color: 5.5.0
-      touch: 3.1.0
-      undefsafe: 2.0.5
-    dev: false
-
-  /nopt@1.0.10:
-    resolution:
-      { integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg== }
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
-    dev: false
-
-  /normalize-package-data@2.5.0:
-    resolution:
-      { integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA== }
-    dependencies:
-      hosted-git-info: 2.8.9
-      resolve: 1.22.8
-      semver: 5.7.2
-      validate-npm-package-license: 3.0.4
-    dev: false
-
-  /normalize-path@3.0.0:
-    resolution:
-      { integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /normalize-url@6.1.0:
-    resolution:
-      { integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A== }
-    engines: { node: ">=10" }
-    dev: false
-
-  /npm-run-path@5.1.0:
-    resolution:
-      { integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q== }
+      { integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg== }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     dependencies:
       path-key: 4.0.0
-    dev: false
-
-  /number-is-nan@1.0.1:
-    resolution:
-      { integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /number-to-bn@1.7.0:
-    resolution:
-      { integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig== }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-    dependencies:
-      bn.js: 4.11.6
-      strip-hex-prefix: 1.0.0
-    dev: false
-
-  /oauth-sign@0.9.0:
-    resolution:
-      { integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ== }
-    dev: false
-
-  /object-assign@4.1.1:
-    resolution:
-      { integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /object-inspect@1.13.1:
-    resolution:
-      { integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ== }
-    dev: false
-
-  /object-keys@0.4.0:
-    resolution:
-      { integrity: sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw== }
-    dev: false
-
-  /object-keys@1.1.1:
-    resolution:
-      { integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /oboe@2.1.5:
-    resolution:
-      { integrity: sha512-zRFWiF+FoicxEs3jNI/WYUrVEgA7DeET/InK0XQuudGHRg8iIob3cNPrJTKaz4004uaA9Pbe+Dwa8iluhjLZWA== }
-    dependencies:
-      http-https: 1.0.0
-    dev: false
-
-  /on-finished@2.4.1:
-    resolution:
-      { integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      ee-first: 1.1.1
     dev: false
 
   /once@1.4.0:
@@ -4468,30 +1613,10 @@ packages:
       mimic-fn: 4.0.0
     dev: false
 
-  /os-locale@1.4.0:
-    resolution:
-      { integrity: sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      lcid: 1.0.0
-    dev: false
-
   /os-tmpdir@1.0.2:
     resolution:
       { integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g== }
     engines: { node: ">=0.10.0" }
-    dev: false
-
-  /p-cancelable@2.1.1:
-    resolution:
-      { integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg== }
-    engines: { node: ">=8" }
-    dev: false
-
-  /p-cancelable@3.0.0:
-    resolution:
-      { integrity: sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw== }
-    engines: { node: ">=12.20" }
     dev: false
 
   /param-case@3.0.4:
@@ -4510,19 +1635,6 @@ packages:
       callsites: 3.1.0
     dev: false
 
-  /parse-headers@2.0.5:
-    resolution:
-      { integrity: sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA== }
-    dev: false
-
-  /parse-json@2.2.0:
-    resolution:
-      { integrity: sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      error-ex: 1.3.2
-    dev: false
-
   /parse-json@5.2.0:
     resolution:
       { integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg== }
@@ -4532,12 +1644,6 @@ packages:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-    dev: false
-
-  /parseurl@1.3.3:
-    resolution:
-      { integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ== }
-    engines: { node: ">= 0.8" }
     dev: false
 
   /pascal-case@3.1.2:
@@ -4556,14 +1662,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /path-exists@2.1.0:
-    resolution:
-      { integrity: sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      pinkie-promise: 2.0.1
-    dev: false
-
   /path-key@3.1.1:
     resolution:
       { integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q== }
@@ -4575,11 +1673,6 @@ packages:
     engines: { node: ">=12" }
     dev: false
 
-  /path-parse@1.0.7:
-    resolution:
-      { integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw== }
-    dev: false
-
   /path-scurry@1.10.1:
     resolution:
       { integrity: sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ== }
@@ -4588,21 +1681,6 @@ packages:
       lru-cache: 10.1.0
       minipass: 7.0.4
     dev: true
-
-  /path-to-regexp@0.1.7:
-    resolution:
-      { integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ== }
-    dev: false
-
-  /path-type@1.1.0:
-    resolution:
-      { integrity: sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      graceful-fs: 4.2.11
-      pify: 2.3.0
-      pinkie-promise: 2.0.1
-    dev: false
 
   /path-type@4.0.0:
     resolution:
@@ -4613,35 +1691,6 @@ packages:
   /pathval@1.1.1:
     resolution:
       { integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ== }
-    dev: false
-
-  /pbkdf2@3.1.2:
-    resolution:
-      { integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA== }
-    engines: { node: ">=0.12" }
-    dependencies:
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      ripemd160: 2.0.2
-      safe-buffer: 5.2.1
-      sha.js: 2.4.11
-    dev: false
-
-  /pegjs@0.10.0:
-    resolution:
-      { integrity: sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow== }
-    engines: { node: ">=0.10" }
-    hasBin: true
-    dev: false
-
-  /performance-now@2.1.0:
-    resolution:
-      { integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow== }
-    dev: false
-
-  /picocolors@1.0.0:
-    resolution:
-      { integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ== }
     dev: false
 
   /picomatch@2.3.1:
@@ -4657,48 +1706,10 @@ packages:
     hasBin: true
     dev: false
 
-  /pify@2.3.0:
-    resolution:
-      { integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /pify@3.0.0:
-    resolution:
-      { integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg== }
-    engines: { node: ">=4" }
-    dev: false
-
-  /pify@5.0.0:
-    resolution:
-      { integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA== }
-    engines: { node: ">=10" }
-    dev: false
-
-  /pinkie-promise@2.0.1:
-    resolution:
-      { integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      pinkie: 2.0.4
-    dev: false
-
-  /pinkie@2.0.4:
-    resolution:
-      { integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
   /pluralize@8.0.0:
     resolution:
       { integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA== }
     engines: { node: ">=4" }
-    dev: false
-
-  /precond@0.2.3:
-    resolution:
-      { integrity: sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ== }
-    engines: { node: ">= 0.6" }
     dev: false
 
   /prettier-linter-helpers@1.0.0:
@@ -4709,17 +1720,17 @@ packages:
       fast-diff: 1.3.0
     dev: false
 
-  /prettier-plugin-solidity@1.2.0(prettier@2.8.8):
+  /prettier-plugin-solidity@1.3.1(prettier@3.2.2):
     resolution:
-      { integrity: sha512-fgxcUZpVAP+LlRfy5JI5oaAkXGkmsje2VJ5krv/YMm+rcTZbIUwFguSw5f+WFuttMjpDm6wB4UL7WVkArEfiVA== }
+      { integrity: sha512-MN4OP5I2gHAzHZG1wcuJl0FsLS3c4Cc5494bbg+6oQWBPuEamjwDvmGfFMZ6NFzsh3Efd9UUxeT7ImgjNH4ozA== }
     engines: { node: ">=16" }
     peerDependencies:
       prettier: ">=2.3.0"
     dependencies:
-      "@solidity-parser/parser": 0.16.2
-      prettier: 2.8.8
+      "@solidity-parser/parser": 0.17.0
+      prettier: 3.2.2
       semver: 7.5.4
-      solidity-comments-extractor: 0.0.7
+      solidity-comments-extractor: 0.0.8
     dev: false
 
   /prettier@2.8.8:
@@ -4727,64 +1738,15 @@ packages:
       { integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q== }
     engines: { node: ">=10.13.0" }
     hasBin: true
+    requiresBuild: true
     dev: false
+    optional: true
 
-  /process-nextick-args@2.0.1:
+  /prettier@3.2.2:
     resolution:
-      { integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag== }
-    dev: false
-
-  /process@0.11.10:
-    resolution:
-      { integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A== }
-    engines: { node: ">= 0.6.0" }
-    dev: false
-
-  /promise-to-callback@1.0.0:
-    resolution:
-      { integrity: sha512-uhMIZmKM5ZteDMfLgJnoSq9GCwsNKrYau73Awf1jIy6/eUcuuZ3P+CD9zUv0kJsIUbU+x6uLNIhXhLHDs1pNPA== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      is-fn: 1.0.0
-      set-immediate-shim: 1.0.1
-    dev: false
-
-  /proxy-addr@2.0.7:
-    resolution:
-      { integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg== }
-    engines: { node: ">= 0.10" }
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-    dev: false
-
-  /prr@1.0.1:
-    resolution:
-      { integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw== }
-    dev: false
-
-  /psl@1.9.0:
-    resolution:
-      { integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag== }
-    dev: false
-
-  /pstree.remy@1.1.8:
-    resolution:
-      { integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w== }
-    dev: false
-
-  /pump@3.0.0:
-    resolution:
-      { integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww== }
-    dependencies:
-      end-of-stream: 1.4.4
-      once: 1.4.0
-    dev: false
-
-  /punycode@2.1.0:
-    resolution:
-      { integrity: sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA== }
-    engines: { node: ">=6" }
+      { integrity: sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A== }
+    engines: { node: ">=14" }
+    hasBin: true
     dev: false
 
   /punycode@2.3.1:
@@ -4793,178 +1755,9 @@ packages:
     engines: { node: ">=6" }
     dev: false
 
-  /qs@6.11.0:
+  /regenerator-runtime@0.14.1:
     resolution:
-      { integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q== }
-    engines: { node: ">=0.6" }
-    dependencies:
-      side-channel: 1.0.4
-    dev: false
-
-  /qs@6.5.3:
-    resolution:
-      { integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA== }
-    engines: { node: ">=0.6" }
-    dev: false
-
-  /query-string@5.1.1:
-    resolution:
-      { integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      decode-uri-component: 0.2.2
-      object-assign: 4.1.1
-      strict-uri-encode: 1.1.0
-    dev: false
-
-  /quick-lru@5.1.1:
-    resolution:
-      { integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA== }
-    engines: { node: ">=10" }
-    dev: false
-
-  /randombytes@2.1.0:
-    resolution:
-      { integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ== }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /range-parser@1.2.1:
-    resolution:
-      { integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg== }
-    engines: { node: ">= 0.6" }
-    dev: false
-
-  /raw-body@2.5.1:
-    resolution:
-      { integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
-    dev: false
-
-  /raw-body@2.5.2:
-    resolution:
-      { integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA== }
-    engines: { node: ">= 0.8" }
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
-    dev: false
-
-  /read-pkg-up@1.0.1:
-    resolution:
-      { integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      find-up: 1.1.2
-      read-pkg: 1.1.0
-    dev: false
-
-  /read-pkg@1.1.0:
-    resolution:
-      { integrity: sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      load-json-file: 1.1.0
-      normalize-package-data: 2.5.0
-      path-type: 1.1.0
-    dev: false
-
-  /readable-stream@1.0.34:
-    resolution:
-      { integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg== }
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-
-  /readable-stream@1.1.14:
-    resolution:
-      { integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ== }
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 0.0.1
-      string_decoder: 0.10.31
-    dev: false
-
-  /readable-stream@2.3.8:
-    resolution:
-      { integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA== }
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-    dev: false
-
-  /readable-stream@3.6.2:
-    resolution:
-      { integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA== }
-    engines: { node: ">= 6" }
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-    dev: false
-
-  /readdirp@3.6.0:
-    resolution:
-      { integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA== }
-    engines: { node: ">=8.10.0" }
-    dependencies:
-      picomatch: 2.3.1
-    dev: false
-
-  /regenerator-runtime@0.14.0:
-    resolution:
-      { integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA== }
-    dev: false
-
-  /request@2.88.2:
-    resolution:
-      { integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw== }
-    engines: { node: ">= 6" }
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.12.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.3
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    dev: false
-
-  /require-directory@2.1.1:
-    resolution:
-      { integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q== }
-    engines: { node: ">=0.10.0" }
+      { integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw== }
     dev: false
 
   /require-from-string@2.0.2:
@@ -4973,37 +1766,10 @@ packages:
     engines: { node: ">=0.10.0" }
     dev: false
 
-  /require-main-filename@1.0.1:
-    resolution:
-      { integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug== }
-    dev: false
-
-  /resolve-alpn@1.2.1:
-    resolution:
-      { integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g== }
-    dev: false
-
   /resolve-from@4.0.0:
     resolution:
       { integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g== }
     engines: { node: ">=4" }
-    dev: false
-
-  /resolve@1.22.8:
-    resolution:
-      { integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw== }
-    hasBin: true
-    dependencies:
-      is-core-module: 2.13.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-    dev: false
-
-  /responselike@2.0.1:
-    resolution:
-      { integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw== }
-    dependencies:
-      lowercase-keys: 2.0.0
     dev: false
 
   /restore-cursor@4.0.0:
@@ -5020,87 +1786,14 @@ packages:
       { integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA== }
     dev: false
 
-  /ripemd160@2.0.2:
-    resolution:
-      { integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA== }
-    dependencies:
-      hash-base: 3.1.0
-      inherits: 2.0.4
-    dev: false
-
-  /rlp@2.2.7:
-    resolution:
-      { integrity: sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ== }
-    hasBin: true
-    dependencies:
-      bn.js: 5.2.1
-    dev: false
-
-  /rustbn.js@0.2.0:
-    resolution:
-      { integrity: sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA== }
-    dev: false
-
-  /safe-buffer@5.1.2:
-    resolution:
-      { integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g== }
-    dev: false
-
-  /safe-buffer@5.2.1:
-    resolution:
-      { integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ== }
-    dev: false
-
-  /safe-event-emitter@1.0.1:
-    resolution:
-      { integrity: sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg== }
-    deprecated: Renamed to @metamask/safe-event-emitter
-    dependencies:
-      events: 3.3.0
-    dev: false
-
-  /safer-buffer@2.1.2:
-    resolution:
-      { integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg== }
-    dev: false
-
   /scrypt-js@3.0.1:
     resolution:
       { integrity: sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA== }
     dev: false
 
-  /secp256k1@4.0.3:
-    resolution:
-      { integrity: sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA== }
-    engines: { node: ">=10.0.0" }
-    requiresBuild: true
-    dependencies:
-      elliptic: 6.5.4
-      node-addon-api: 2.0.2
-      node-gyp-build: 4.7.1
-    dev: false
-
-  /semaphore@1.1.0:
-    resolution:
-      { integrity: sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA== }
-    engines: { node: ">=0.8.0" }
-    dev: false
-
-  /semver@5.4.1:
-    resolution:
-      { integrity: sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg== }
-    hasBin: true
-    dev: false
-
   /semver@5.7.2:
     resolution:
       { integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g== }
-    hasBin: true
-    dev: false
-
-  /semver@6.3.1:
-    resolution:
-      { integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA== }
     hasBin: true
     dev: false
 
@@ -5113,28 +1806,6 @@ packages:
       lru-cache: 6.0.0
     dev: false
 
-  /send@0.18.0:
-    resolution:
-      { integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg== }
-    engines: { node: ">= 0.8.0" }
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.0
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /sentence-case@3.0.4:
     resolution:
       { integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg== }
@@ -5142,74 +1813,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.6.2
       upper-case-first: 2.0.2
-    dev: false
-
-  /serve-static@1.15.0:
-    resolution:
-      { integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g== }
-    engines: { node: ">= 0.8.0" }
-    dependencies:
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.18.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /servify@0.1.12:
-    resolution:
-      { integrity: sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw== }
-    engines: { node: ">=6" }
-    dependencies:
-      body-parser: 1.20.2
-      cors: 2.8.5
-      express: 4.18.2
-      request: 2.88.2
-      xhr: 2.6.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /set-blocking@2.0.0:
-    resolution:
-      { integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw== }
-    dev: false
-
-  /set-function-length@1.1.1:
-    resolution:
-      { integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      define-data-property: 1.1.1
-      get-intrinsic: 1.2.2
-      gopd: 1.0.1
-      has-property-descriptors: 1.0.1
-    dev: false
-
-  /set-immediate-shim@1.0.1:
-    resolution:
-      { integrity: sha512-Li5AOqrZWCVA2n5kryzEmqai6bKSIvpz5oUJHPVj6+dsbD3X1ixtsY5tEnsaNpH3pFAHmG8eIHUrtEtohrg+UQ== }
-    engines: { node: ">=0.10.0" }
-    dev: false
-
-  /setimmediate@1.0.5:
-    resolution:
-      { integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA== }
-    dev: false
-
-  /setprototypeof@1.2.0:
-    resolution:
-      { integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw== }
-    dev: false
-
-  /sha.js@2.4.11:
-    resolution:
-      { integrity: sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ== }
-    hasBin: true
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
     dev: false
 
   /shebang-command@2.0.0:
@@ -5224,20 +1827,6 @@ packages:
       { integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A== }
     engines: { node: ">=8" }
 
-  /side-channel@1.0.4:
-    resolution:
-      { integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw== }
-    dependencies:
-      call-bind: 1.0.5
-      get-intrinsic: 1.2.2
-      object-inspect: 1.13.1
-    dev: false
-
-  /sigmund@1.0.1:
-    resolution:
-      { integrity: sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g== }
-    dev: false
-
   /signal-exit@3.0.7:
     resolution:
       { integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ== }
@@ -5248,28 +1837,6 @@ packages:
       { integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw== }
     engines: { node: ">=14" }
     dev: true
-
-  /simple-concat@1.0.1:
-    resolution:
-      { integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q== }
-    dev: false
-
-  /simple-get@2.8.2:
-    resolution:
-      { integrity: sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw== }
-    dependencies:
-      decompress-response: 3.3.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-    dev: false
-
-  /simple-update-notifier@2.0.0:
-    resolution:
-      { integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w== }
-    engines: { node: ">=10" }
-    dependencies:
-      semver: 7.5.4
-    dev: false
 
   /slice-ansi@4.0.0:
     resolution:
@@ -5306,7 +1873,7 @@ packages:
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.15.3
+      follow-redirects: 1.15.5
       js-sha3: 0.8.0
       memorystream: 0.3.1
       n: 9.2.0
@@ -5316,16 +1883,17 @@ packages:
       - debug
     dev: false
 
-  /solhint-plugin-prettier@0.0.5(prettier-plugin-solidity@1.2.0)(prettier@2.8.8):
+  /solhint-plugin-prettier@0.1.0(prettier-plugin-solidity@1.3.1)(prettier@3.2.2):
     resolution:
-      { integrity: sha512-7jmWcnVshIrO2FFinIvDQmhQpfpS2rRRn3RejiYgnjIE68xO2bvrYvjqVNfrio4xH9ghOqn83tKuTzLjEbmGIA== }
+      { integrity: sha512-SDOTSM6tZxZ6hamrzl3GUgzF77FM6jZplgL2plFBclj/OjKP8Z3eIPojKU73gRr0MvOS8ACZILn8a5g0VTz/Gw== }
     peerDependencies:
-      prettier: ^1.15.0 || ^2.0.0
-      prettier-plugin-solidity: ^1.0.0-alpha.14
+      prettier: ^3.0.0
+      prettier-plugin-solidity: ^1.0.0
     dependencies:
-      prettier: 2.8.8
+      "@prettier/sync": 0.3.0(prettier@3.2.2)
+      prettier: 3.2.2
       prettier-linter-helpers: 1.0.0
-      prettier-plugin-solidity: 1.2.0(prettier@2.8.8)
+      prettier-plugin-solidity: 1.3.1(prettier@3.2.2)
     dev: false
 
   /solhint@3.6.2(typescript@5.3.3):
@@ -5356,90 +1924,23 @@ packages:
       - typescript
     dev: false
 
-  /solidity-comments-extractor@0.0.7:
+  /solidity-bytes-utils@0.8.2:
     resolution:
-      { integrity: sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw== }
-    dev: false
-
-  /solidity-parser@0.4.0:
-    resolution:
-      { integrity: sha512-kMmbEZ5vDoK+0JFHvC/sVrAB3yQs1u8g+Eeo/Q+G2oAiqCxpKQHgESbOYNBRXYCyXJgtpTlCoNjtpV2x+tfodg== }
-    hasBin: true
+      { integrity: sha512-cqXPYAV2auhpdKSTPuqji0CwpSceZDu95CzqSM/9tDJ2MoMaMsdHTpOIWtVw31BIqqGPNmIChCswzbw0tHaMTw== }
     dependencies:
-      mocha: 2.5.3
-      pegjs: 0.10.0
-      yargs: 4.8.1
+      ds-test: github.com/dapphub/ds-test/e282159d5170298eb2455a6c05280ab5a73a4ef0
+      forge-std: 1.1.2
     dev: false
 
-  /spdx-correct@3.2.0:
+  /solidity-comments-extractor@0.0.8:
     resolution:
-      { integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA== }
-    dependencies:
-      spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.16
-    dev: false
-
-  /spdx-exceptions@2.3.0:
-    resolution:
-      { integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A== }
-    dev: false
-
-  /spdx-expression-parse@3.0.1:
-    resolution:
-      { integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q== }
-    dependencies:
-      spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.16
-    dev: false
-
-  /spdx-license-ids@3.0.16:
-    resolution:
-      { integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw== }
-    dev: false
-
-  /sshpk@1.18.0:
-    resolution:
-      { integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ== }
-    engines: { node: ">=0.10.0" }
-    hasBin: true
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-    dev: false
-
-  /statuses@2.0.1:
-    resolution:
-      { integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /strict-uri-encode@1.1.0:
-    resolution:
-      { integrity: sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ== }
-    engines: { node: ">=0.10.0" }
+      { integrity: sha512-htM7Vn6LhHreR+EglVMd2s+sZhcXAirB1Zlyrv5zBuTxieCvjfnRpd7iZk75m/u6NOlEyQ94C6TWbBn2cY7w8g== }
     dev: false
 
   /string-argv@0.3.2:
     resolution:
       { integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q== }
     engines: { node: ">=0.6.19" }
-    dev: false
-
-  /string-width@1.0.2:
-    resolution:
-      { integrity: sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      code-point-at: 1.1.0
-      is-fullwidth-code-point: 1.0.0
-      strip-ansi: 3.0.1
     dev: false
 
   /string-width@4.2.3:
@@ -5460,33 +1961,6 @@ packages:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
-  /string_decoder@0.10.31:
-    resolution:
-      { integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ== }
-    dev: false
-
-  /string_decoder@1.1.1:
-    resolution:
-      { integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg== }
-    dependencies:
-      safe-buffer: 5.1.2
-    dev: false
-
-  /string_decoder@1.3.0:
-    resolution:
-      { integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA== }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /strip-ansi@3.0.1:
-    resolution:
-      { integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: false
-
   /strip-ansi@6.0.1:
     resolution:
       { integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A== }
@@ -5501,33 +1975,10 @@ packages:
     dependencies:
       ansi-regex: 6.0.1
 
-  /strip-bom@2.0.0:
-    resolution:
-      { integrity: sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      is-utf8: 0.2.1
-    dev: false
-
   /strip-final-newline@3.0.0:
     resolution:
       { integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw== }
     engines: { node: ">=12" }
-    dev: false
-
-  /strip-hex-prefix@1.0.0:
-    resolution:
-      { integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A== }
-    engines: { node: ">=6.5.0", npm: ">=3" }
-    dependencies:
-      is-hex-prefixed: 1.0.0
-    dev: false
-
-  /supports-color@1.2.0:
-    resolution:
-      { integrity: sha512-mS5xsnjTh5b7f2DM6bch6lR582UCOTphzINlZnDsfpIRrwI6r58rb6YSSGsdexkm8qw2bBVO2ID2fnJOTuLiPA== }
-    engines: { node: ">=0.10.0" }
-    hasBin: true
     dev: false
 
   /supports-color@5.5.0:
@@ -5546,33 +1997,6 @@ packages:
       has-flag: 4.0.0
     dev: false
 
-  /supports-preserve-symlinks-flag@1.0.0:
-    resolution:
-      { integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w== }
-    engines: { node: ">= 0.4" }
-    dev: false
-
-  /swarm-js@0.1.42:
-    resolution:
-      { integrity: sha512-BV7c/dVlA3R6ya1lMlSSNPLYrntt0LUq4YMgy3iwpCIc6rZnS5W2wUoctarZ5pXlpKtxDDf9hNziEkcfrxdhqQ== }
-    dependencies:
-      bluebird: 3.7.2
-      buffer: 5.7.1
-      eth-lib: 0.1.29
-      fs-extra: 4.0.3
-      got: 11.8.6
-      mime-types: 2.1.35
-      mkdirp-promise: 5.0.1
-      mock-fs: 4.14.0
-      setimmediate: 1.0.5
-      tar: 4.4.19
-      xhr-request: 1.1.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
   /table@6.8.1:
     resolution:
       { integrity: sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA== }
@@ -5585,29 +2009,9 @@ packages:
       strip-ansi: 6.0.1
     dev: false
 
-  /tar@4.4.19:
-    resolution:
-      { integrity: sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA== }
-    engines: { node: ">=4.5" }
-    dependencies:
-      chownr: 1.1.4
-      fs-minipass: 1.2.7
-      minipass: 2.9.0
-      minizlib: 1.3.3
-      mkdirp: 0.5.6
-      safe-buffer: 5.2.1
-      yallist: 3.1.1
-    dev: false
-
   /text-table@0.2.0:
     resolution:
       { integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw== }
-    dev: false
-
-  /timed-out@4.0.1:
-    resolution:
-      { integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA== }
-    engines: { node: ">=0.10.0" }
     dev: false
 
   /tmp@0.0.33:
@@ -5618,18 +2022,6 @@ packages:
       os-tmpdir: 1.0.2
     dev: false
 
-  /to-fast-properties@2.0.0:
-    resolution:
-      { integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog== }
-    engines: { node: ">=4" }
-    dev: false
-
-  /to-iso-string@0.0.2:
-    resolution:
-      { integrity: sha512-oeHLgfWA7d0CPQa6h0+i5DAJZISz5un0d5SHPkw+Untclcvzv9T+AC3CvGXlZJdOlIbxbTfyyzlqCXc5hjpXYg== }
-    deprecated: to-iso-string has been deprecated, use @segment/to-iso-string instead.
-    dev: false
-
   /to-regex-range@5.0.1:
     resolution:
       { integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ== }
@@ -5638,40 +2030,12 @@ packages:
       is-number: 7.0.0
     dev: false
 
-  /toidentifier@1.0.1:
-    resolution:
-      { integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA== }
-    engines: { node: ">=0.6" }
-    dev: false
-
   /toml@3.0.0:
     resolution:
       { integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w== }
     dev: false
 
-  /touch@3.1.0:
-    resolution:
-      { integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA== }
-    hasBin: true
-    dependencies:
-      nopt: 1.0.10
-    dev: false
-
-  /tough-cookie@2.5.0:
-    resolution:
-      { integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g== }
-    engines: { node: ">=0.8" }
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.3.1
-    dev: false
-
-  /tr46@0.0.3:
-    resolution:
-      { integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw== }
-    dev: false
-
-  /ts-node@10.9.2(@types/node@18.19.3)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@18.19.7)(typescript@5.3.3):
     resolution:
       { integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ== }
     hasBin: true
@@ -5691,9 +2055,9 @@ packages:
       "@tsconfig/node12": 1.0.11
       "@tsconfig/node14": 1.0.3
       "@tsconfig/node16": 1.0.4
-      "@types/node": 18.19.3
-      acorn: 8.11.2
-      acorn-walk: 8.3.1
+      "@types/node": 18.19.7
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -5708,28 +2072,6 @@ packages:
       { integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q== }
     dev: false
 
-  /tunnel-agent@0.6.0:
-    resolution:
-      { integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w== }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /tweetnacl-util@0.15.1:
-    resolution:
-      { integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw== }
-    dev: false
-
-  /tweetnacl@0.14.5:
-    resolution:
-      { integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA== }
-    dev: false
-
-  /tweetnacl@1.0.3:
-    resolution:
-      { integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw== }
-    dev: false
-
   /type-detect@4.0.8:
     resolution:
       { integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g== }
@@ -5742,32 +2084,6 @@ packages:
     engines: { node: ">=10" }
     dev: false
 
-  /type-is@1.6.18:
-    resolution:
-      { integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g== }
-    engines: { node: ">= 0.6" }
-    dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
-    dev: false
-
-  /type@1.2.0:
-    resolution:
-      { integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg== }
-    dev: false
-
-  /type@2.7.2:
-    resolution:
-      { integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw== }
-    dev: false
-
-  /typedarray-to-buffer@3.1.5:
-    resolution:
-      { integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q== }
-    dependencies:
-      is-typedarray: 1.0.0
-    dev: false
-
   /typescript@5.3.3:
     resolution:
       { integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw== }
@@ -5775,49 +2091,15 @@ packages:
     hasBin: true
     dev: false
 
-  /ultron@1.1.1:
-    resolution:
-      { integrity: sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og== }
-    dev: false
-
-  /undefsafe@2.0.5:
-    resolution:
-      { integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA== }
-    dev: false
-
   /undici-types@5.26.5:
     resolution:
       { integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA== }
-    dev: false
-
-  /universalify@0.1.2:
-    resolution:
-      { integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg== }
-    engines: { node: ">= 4.0.0" }
     dev: false
 
   /universalify@2.0.1:
     resolution:
       { integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw== }
     engines: { node: ">= 10.0.0" }
-    dev: false
-
-  /unpipe@1.0.0:
-    resolution:
-      { integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /update-browserslist-db@1.0.13(browserslist@4.22.2):
-    resolution:
-      { integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg== }
-    hasBin: true
-    peerDependencies:
-      browserslist: ">= 4.21.0"
-    dependencies:
-      browserslist: 4.22.2
-      escalade: 3.1.1
-      picocolors: 1.0.0
     dev: false
 
   /upper-case-first@2.0.2:
@@ -5841,470 +2123,9 @@ packages:
       punycode: 2.3.1
     dev: false
 
-  /url-set-query@1.0.0:
-    resolution:
-      { integrity: sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg== }
-    dev: false
-
-  /utf-8-validate@5.0.10:
-    resolution:
-      { integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ== }
-    engines: { node: ">=6.14.2" }
-    requiresBuild: true
-    dependencies:
-      node-gyp-build: 4.7.1
-    dev: false
-
-  /utf8@3.0.0:
-    resolution:
-      { integrity: sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ== }
-    dev: false
-
-  /util-deprecate@1.0.2:
-    resolution:
-      { integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw== }
-    dev: false
-
-  /util@0.12.5:
-    resolution:
-      { integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA== }
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.12
-      which-typed-array: 1.1.13
-    dev: false
-
-  /utils-merge@1.0.1:
-    resolution:
-      { integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA== }
-    engines: { node: ">= 0.4.0" }
-    dev: false
-
-  /uuid@3.4.0:
-    resolution:
-      { integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A== }
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
-
-  /uuid@9.0.1:
-    resolution:
-      { integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA== }
-    hasBin: true
-    dev: false
-
   /v8-compile-cache-lib@3.0.1:
     resolution:
       { integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg== }
-    dev: false
-
-  /validate-npm-package-license@3.0.4:
-    resolution:
-      { integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew== }
-    dependencies:
-      spdx-correct: 3.2.0
-      spdx-expression-parse: 3.0.1
-    dev: false
-
-  /varint@5.0.2:
-    resolution:
-      { integrity: sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow== }
-    dev: false
-
-  /vary@1.1.2:
-    resolution:
-      { integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg== }
-    engines: { node: ">= 0.8" }
-    dev: false
-
-  /verror@1.10.0:
-    resolution:
-      { integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw== }
-    engines: { "0": node >=0.6.0 }
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
-    dev: false
-
-  /web3-bzz@1.10.0:
-    resolution:
-      { integrity: sha512-o9IR59io3pDUsXTsps5pO5hW1D5zBmg46iNc2t4j2DkaYHNdDLwk2IP9ukoM2wg47QILfPEJYzhTfkS/CcX0KA== }
-    engines: { node: ">=8.0.0" }
-    requiresBuild: true
-    dependencies:
-      "@types/node": 12.20.55
-      got: 12.1.0
-      swarm-js: 0.1.42
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /web3-core-helpers@1.10.0:
-    resolution:
-      { integrity: sha512-pIxAzFDS5vnbXvfvLSpaA1tfRykAe9adw43YCKsEYQwH0gCLL0kMLkaCX3q+Q8EVmAh+e1jWL/nl9U0de1+++g== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      web3-eth-iban: 1.10.0
-      web3-utils: 1.10.0
-    dev: false
-
-  /web3-core-method@1.10.0:
-    resolution:
-      { integrity: sha512-4R700jTLAMKDMhQ+nsVfIXvH6IGJlJzGisIfMKWAIswH31h5AZz7uDUW2YctI+HrYd+5uOAlS4OJeeT9bIpvkA== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@ethersproject/transactions": 5.7.0
-      web3-core-helpers: 1.10.0
-      web3-core-promievent: 1.10.0
-      web3-core-subscriptions: 1.10.0
-      web3-utils: 1.10.0
-    dev: false
-
-  /web3-core-promievent@1.10.0:
-    resolution:
-      { integrity: sha512-68N7k5LWL5R38xRaKFrTFT2pm2jBNFaM4GioS00YjAKXRQ3KjmhijOMG3TICz6Aa5+6GDWYelDNx21YAeZ4YTg== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      eventemitter3: 4.0.4
-    dev: false
-
-  /web3-core-requestmanager@1.10.0:
-    resolution:
-      { integrity: sha512-3z/JKE++Os62APml4dvBM+GAuId4h3L9ckUrj7ebEtS2AR0ixyQPbrBodgL91Sv7j7cQ3Y+hllaluqjguxvSaQ== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      util: 0.12.5
-      web3-core-helpers: 1.10.0
-      web3-providers-http: 1.10.0
-      web3-providers-ipc: 1.10.0
-      web3-providers-ws: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-core-subscriptions@1.10.0:
-    resolution:
-      { integrity: sha512-HGm1PbDqsxejI075gxBc5OSkwymilRWZufIy9zEpnWKNmfbuv5FfHgW1/chtJP6aP3Uq2vHkvTDl3smQBb8l+g== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      eventemitter3: 4.0.4
-      web3-core-helpers: 1.10.0
-    dev: false
-
-  /web3-core@1.10.0:
-    resolution:
-      { integrity: sha512-fWySwqy2hn3TL89w5TM8wXF1Z2Q6frQTKHWmP0ppRQorEK8NcHJRfeMiv/mQlSKoTS1F6n/nv2uyZsixFycjYQ== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@types/bn.js": 5.1.5
-      "@types/node": 12.20.55
-      bignumber.js: 9.1.2
-      web3-core-helpers: 1.10.0
-      web3-core-method: 1.10.0
-      web3-core-requestmanager: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-eth-abi@1.10.0:
-    resolution:
-      { integrity: sha512-cwS+qRBWpJ43aI9L3JS88QYPfFcSJJ3XapxOQ4j40v6mk7ATpA8CVK1vGTzpihNlOfMVRBkR95oAj7oL6aiDOg== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@ethersproject/abi": 5.7.0
-      web3-utils: 1.10.0
-    dev: false
-
-  /web3-eth-accounts@1.10.0:
-    resolution:
-      { integrity: sha512-wiq39Uc3mOI8rw24wE2n15hboLE0E9BsQLdlmsL4Zua9diDS6B5abXG0XhFcoNsXIGMWXVZz4TOq3u4EdpXF/Q== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@ethereumjs/common": 2.5.0
-      "@ethereumjs/tx": 3.3.2
-      eth-lib: 0.2.8
-      ethereumjs-util: 7.1.5
-      scrypt-js: 3.0.1
-      uuid: 9.0.1
-      web3-core: 1.10.0
-      web3-core-helpers: 1.10.0
-      web3-core-method: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-eth-contract@1.10.0:
-    resolution:
-      { integrity: sha512-MIC5FOzP/+2evDksQQ/dpcXhSqa/2hFNytdl/x61IeWxhh6vlFeSjq0YVTAyIzdjwnL7nEmZpjfI6y6/Ufhy7w== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@types/bn.js": 5.1.5
-      web3-core: 1.10.0
-      web3-core-helpers: 1.10.0
-      web3-core-method: 1.10.0
-      web3-core-promievent: 1.10.0
-      web3-core-subscriptions: 1.10.0
-      web3-eth-abi: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-eth-ens@1.10.0:
-    resolution:
-      { integrity: sha512-3hpGgzX3qjgxNAmqdrC2YUQMTfnZbs4GeLEmy8aCWziVwogbuqQZ+Gzdfrym45eOZodk+lmXyLuAdqkNlvkc1g== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      content-hash: 2.5.2
-      eth-ens-namehash: 2.0.8
-      web3-core: 1.10.0
-      web3-core-helpers: 1.10.0
-      web3-core-promievent: 1.10.0
-      web3-eth-abi: 1.10.0
-      web3-eth-contract: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-eth-iban@1.10.0:
-    resolution:
-      { integrity: sha512-0l+SP3IGhInw7Q20LY3IVafYEuufo4Dn75jAHT7c2aDJsIolvf2Lc6ugHkBajlwUneGfbRQs/ccYPQ9JeMUbrg== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      bn.js: 5.2.1
-      web3-utils: 1.10.0
-    dev: false
-
-  /web3-eth-personal@1.10.0:
-    resolution:
-      { integrity: sha512-anseKn98w/d703eWq52uNuZi7GhQeVjTC5/svrBWEKob0WZ5kPdo+EZoFN0sp5a5ubbrk/E0xSl1/M5yORMtpg== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      "@types/node": 12.20.55
-      web3-core: 1.10.0
-      web3-core-helpers: 1.10.0
-      web3-core-method: 1.10.0
-      web3-net: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-eth@1.10.0:
-    resolution:
-      { integrity: sha512-Z5vT6slNMLPKuwRyKGbqeGYC87OAy8bOblaqRTgg94CXcn/mmqU7iPIlG4506YdcdK3x6cfEDG7B6w+jRxypKA== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      web3-core: 1.10.0
-      web3-core-helpers: 1.10.0
-      web3-core-method: 1.10.0
-      web3-core-subscriptions: 1.10.0
-      web3-eth-abi: 1.10.0
-      web3-eth-accounts: 1.10.0
-      web3-eth-contract: 1.10.0
-      web3-eth-ens: 1.10.0
-      web3-eth-iban: 1.10.0
-      web3-eth-personal: 1.10.0
-      web3-net: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-net@1.10.0:
-    resolution:
-      { integrity: sha512-NLH/N3IshYWASpxk4/18Ge6n60GEvWBVeM8inx2dmZJVmRI6SJIlUxbL8jySgiTn3MMZlhbdvrGo8fpUW7a1GA== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      web3-core: 1.10.0
-      web3-core-method: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-provider-engine@16.0.3(@babel/core@7.23.7):
-    resolution:
-      { integrity: sha512-Q3bKhGqLfMTdLvkd4TtkGYJHcoVQ82D1l8jTIwwuJp/sAp7VHnRYb9YJ14SW/69VMWoOhSpPLZV2tWb9V0WJoA== }
-    engines: { node: ">=12.0.0" }
-    dependencies:
-      "@ethereumjs/tx": 3.5.2
-      async: 2.6.4
-      backoff: 2.5.0
-      clone: 2.1.2
-      cross-fetch: 2.2.6
-      eth-block-tracker: 4.4.3(@babel/core@7.23.7)
-      eth-json-rpc-filters: 4.2.2
-      eth-json-rpc-infura: 5.1.0
-      eth-json-rpc-middleware: 6.0.0
-      eth-rpc-errors: 3.0.0
-      eth-sig-util: 1.4.2
-      ethereumjs-block: 1.7.1
-      ethereumjs-util: 5.2.1
-      ethereumjs-vm: 2.6.0
-      json-stable-stringify: 1.1.0
-      promise-to-callback: 1.0.0
-      readable-stream: 2.3.8
-      request: 2.88.2
-      semaphore: 1.1.0
-      ws: 5.2.3
-      xhr: 2.6.0
-      xtend: 4.0.2
-    transitivePeerDependencies:
-      - "@babel/core"
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /web3-providers-http@1.10.0:
-    resolution:
-      { integrity: sha512-eNr965YB8a9mLiNrkjAWNAPXgmQWfpBfkkn7tpEFlghfww0u3I0tktMZiaToJVcL2+Xq+81cxbkpeWJ5XQDwOA== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      abortcontroller-polyfill: 1.7.5
-      cross-fetch: 3.1.8
-      es6-promise: 4.2.8
-      web3-core-helpers: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /web3-providers-ipc@1.10.0:
-    resolution:
-      { integrity: sha512-OfXG1aWN8L1OUqppshzq8YISkWrYHaATW9H8eh0p89TlWMc1KZOL9vttBuaBEi96D/n0eYDn2trzt22bqHWfXA== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      oboe: 2.1.5
-      web3-core-helpers: 1.10.0
-    dev: false
-
-  /web3-providers-ws@1.10.0:
-    resolution:
-      { integrity: sha512-sK0fNcglW36yD5xjnjtSGBnEtf59cbw4vZzJ+CmOWIKGIR96mP5l684g0WD0Eo+f4NQc2anWWXG74lRc9OVMCQ== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      eventemitter3: 4.0.4
-      web3-core-helpers: 1.10.0
-      websocket: 1.0.34
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /web3-shh@1.10.0:
-    resolution:
-      { integrity: sha512-uNUUuNsO2AjX41GJARV9zJibs11eq6HtOe6Wr0FtRUcj8SN6nHeYIzwstAvJ4fXA53gRqFMTxdntHEt9aXVjpg== }
-    engines: { node: ">=8.0.0" }
-    requiresBuild: true
-    dependencies:
-      web3-core: 1.10.0
-      web3-core-method: 1.10.0
-      web3-core-subscriptions: 1.10.0
-      web3-net: 1.10.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /web3-utils@1.10.0:
-    resolution:
-      { integrity: sha512-kSaCM0uMcZTNUSmn5vMEhlo02RObGNRRCkdX0V9UTAU0+lrvn0HSaudyCo6CQzuXUsnuY2ERJGCGPfeWmv19Rg== }
-    engines: { node: ">=8.0.0" }
-    dependencies:
-      bn.js: 5.2.1
-      ethereum-bloom-filters: 1.0.10
-      ethereumjs-util: 7.1.5
-      ethjs-unit: 0.1.6
-      number-to-bn: 1.7.0
-      randombytes: 2.1.0
-      utf8: 3.0.0
-    dev: false
-
-  /web3@1.10.0:
-    resolution:
-      { integrity: sha512-YfKY9wSkGcM8seO+daR89oVTcbu18NsVfvOngzqMYGUU0pPSQmE57qQDvQzUeoIOHAnXEBNzrhjQJmm8ER0rng== }
-    engines: { node: ">=8.0.0" }
-    requiresBuild: true
-    dependencies:
-      web3-bzz: 1.10.0
-      web3-core: 1.10.0
-      web3-eth: 1.10.0
-      web3-eth-personal: 1.10.0
-      web3-net: 1.10.0
-      web3-shh: 1.10.0
-      web3-utils: 1.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /webidl-conversions@3.0.1:
-    resolution:
-      { integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ== }
-    dev: false
-
-  /websocket@1.0.34:
-    resolution:
-      { integrity: sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ== }
-    engines: { node: ">=4.0.0" }
-    dependencies:
-      bufferutil: 4.0.8
-      debug: 2.6.9
-      es5-ext: 0.10.62
-      typedarray-to-buffer: 3.1.5
-      utf-8-validate: 5.0.10
-      yaeti: 0.0.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /whatwg-fetch@2.0.4:
-    resolution:
-      { integrity: sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng== }
-    dev: false
-
-  /whatwg-url@5.0.0:
-    resolution:
-      { integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw== }
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-    dev: false
-
-  /which-module@1.0.0:
-    resolution:
-      { integrity: sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ== }
-    dev: false
-
-  /which-typed-array@1.1.13:
-    resolution:
-      { integrity: sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow== }
-    engines: { node: ">= 0.4" }
-    dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.5
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
     dev: false
 
   /which@2.0.2:
@@ -6314,22 +2135,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-
-  /window-size@0.2.0:
-    resolution:
-      { integrity: sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw== }
-    engines: { node: ">= 0.10.0" }
-    hasBin: true
-    dev: false
-
-  /wrap-ansi@2.1.0:
-    resolution:
-      { integrity: sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw== }
-    engines: { node: ">=0.10.0" }
-    dependencies:
-      string-width: 1.0.2
-      strip-ansi: 3.0.1
-    dev: false
 
   /wrap-ansi@7.0.0:
     resolution:
@@ -6355,38 +2160,6 @@ packages:
       { integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ== }
     dev: false
 
-  /ws@3.3.3:
-    resolution:
-      { integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA== }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dependencies:
-      async-limiter: 1.0.1
-      safe-buffer: 5.1.2
-      ultron: 1.1.1
-    dev: false
-
-  /ws@5.2.3:
-    resolution:
-      { integrity: sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA== }
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dependencies:
-      async-limiter: 1.0.1
-    dev: false
-
   /ws@7.4.6:
     resolution:
       { integrity: sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A== }
@@ -6401,66 +2174,6 @@ packages:
         optional: true
     dev: false
 
-  /xhr-request-promise@0.1.3:
-    resolution:
-      { integrity: sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg== }
-    dependencies:
-      xhr-request: 1.1.0
-    dev: false
-
-  /xhr-request@1.1.0:
-    resolution:
-      { integrity: sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA== }
-    dependencies:
-      buffer-to-arraybuffer: 0.0.5
-      object-assign: 4.1.1
-      query-string: 5.1.1
-      simple-get: 2.8.2
-      timed-out: 4.0.1
-      url-set-query: 1.0.0
-      xhr: 2.6.0
-    dev: false
-
-  /xhr@2.6.0:
-    resolution:
-      { integrity: sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA== }
-    dependencies:
-      global: 4.4.0
-      is-function: 1.0.2
-      parse-headers: 2.0.5
-      xtend: 4.0.2
-    dev: false
-
-  /xtend@2.1.2:
-    resolution:
-      { integrity: sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ== }
-    engines: { node: ">=0.4" }
-    dependencies:
-      object-keys: 0.4.0
-    dev: false
-
-  /xtend@4.0.2:
-    resolution:
-      { integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ== }
-    engines: { node: ">=0.4" }
-    dev: false
-
-  /y18n@3.2.2:
-    resolution:
-      { integrity: sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ== }
-    dev: false
-
-  /yaeti@0.0.6:
-    resolution:
-      { integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug== }
-    engines: { node: ">=0.10.32" }
-    dev: false
-
-  /yallist@3.1.1:
-    resolution:
-      { integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g== }
-    dev: false
-
   /yallist@4.0.0:
     resolution:
       { integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A== }
@@ -6472,56 +2185,10 @@ packages:
     engines: { node: ">= 14" }
     dev: false
 
-  /yargs-parser@2.4.1:
-    resolution:
-      { integrity: sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA== }
-    dependencies:
-      camelcase: 3.0.0
-      lodash.assign: 4.2.0
-    dev: false
-
-  /yargs@4.8.1:
-    resolution:
-      { integrity: sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA== }
-    dependencies:
-      cliui: 3.2.0
-      decamelize: 1.2.0
-      get-caller-file: 1.0.3
-      lodash.assign: 4.2.0
-      os-locale: 1.4.0
-      read-pkg-up: 1.0.1
-      require-directory: 2.1.1
-      require-main-filename: 1.0.1
-      set-blocking: 2.0.0
-      string-width: 1.0.2
-      which-module: 1.0.0
-      window-size: 0.2.0
-      y18n: 3.2.2
-      yargs-parser: 2.4.1
-    dev: false
-
   /yn@3.1.1:
     resolution:
       { integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q== }
     engines: { node: ">=6" }
-    dev: false
-
-  github.com/GNSPS/solidity-bytes-utils/42221d3ee53aff8888057fb9f3b7a8fc42c290f8(@babel/core@7.23.7):
-    resolution:
-      {
-        tarball: https://codeload.github.com/GNSPS/solidity-bytes-utils/tar.gz/42221d3ee53aff8888057fb9f3b7a8fc42c290f8,
-      }
-    id: github.com/GNSPS/solidity-bytes-utils/42221d3ee53aff8888057fb9f3b7a8fc42c290f8
-    name: solidity-bytes-utils
-    version: 0.8.1
-    dependencies:
-      "@truffle/hdwallet-provider": 2.1.15(@babel/core@7.23.7)
-    transitivePeerDependencies:
-      - "@babel/core"
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
     dev: false
 
   github.com/dapphub/ds-test/e282159d5170298eb2455a6c05280ab5a73a4ef0:
@@ -6530,19 +2197,13 @@ packages:
     version: 1.0.0
     dev: false
 
-  github.com/ethereumjs/ethereumjs-abi/ee3994657fa7a427238e6ba92a84d0b529bbcde0:
-    resolution:
-      { tarball: https://codeload.github.com/ethereumjs/ethereumjs-abi/tar.gz/ee3994657fa7a427238e6ba92a84d0b529bbcde0 }
-    name: ethereumjs-abi
-    version: 0.6.8
-    dependencies:
-      bn.js: 4.12.0
-      ethereumjs-util: 6.2.1
-    dev: false
-
   github.com/foundry-rs/forge-std/e8a047e3f40f13fa37af6fe14e6e06283d9a060e:
     resolution:
       { tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/e8a047e3f40f13fa37af6fe14e6e06283d9a060e }
     name: forge-std
     version: 1.5.6
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
The primary motivation of this PR is to get `prettier` to ^3.0.0 as there are dependency warnings in using a v2 prettier.