### PR TITLE
Add Generic Storage Slot Viewer

### DIFF
--- a/src/FraxTest.sol
+++ b/src/FraxTest.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.8.0;
 
 import { console2 as console, StdAssertions, StdChains, StdCheats, stdError, StdInvariant, stdJson, stdMath, StdStorage, stdStorage, StdUtils, Vm, StdStyle, TestBase, DSTest, Test } from "forge-std/Test.sol";
-
 import { VmHelper } from "./VmHelper.sol";
+import { Strings } from "src/StringsHelper.sol";
 
 abstract contract FraxTest is VmHelper, Test {
     uint256[] internal snapShotIds;
@@ -27,6 +27,17 @@ abstract contract FraxTest is VmHelper, Test {
             _setupFunctions[i]();
             snapShotIds.push(vm.snapshot());
             vm.clearMockedCalls();
+        }
+    }
+
+    function dumpStorageLayout(address target, uint256 slotsToDump) internal view {
+        console.log("===================================");
+        console.log("Storage dump for: ", target);
+        console.log("===================================");
+        for (uint i; i <= slotsToDump; i++) {
+            bytes32 slot = vm.load(target, bytes32(uint256(i)));
+            string memory exp = Strings.toHexString(uint256(slot), 32);
+            console.log("slot", i, ":", exp);
         }
     }
 

--- a/test/TestSlotDump.t.sol
+++ b/test/TestSlotDump.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.0;
+
+import "../src/FraxTest.sol";
+
+contract TestSlotDump is FraxTest {
+    address instance;
+
+    function testDumpSlots() public {
+        instance = address(new Bravo());
+        dumpStorageLayout(instance, 15);
+    }
+}
+
+// ================== Helpers =============
+
+contract Alpha {
+    address owner = address(0xC0ffee);
+    address pendingOwner;
+}
+
+contract Bravo is Alpha {
+    bytes32 someValue = bytes32(type(uint).max);
+    uint256[5] gap;
+    bytes32 someOtherValue = 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA;
+}


### PR DESCRIPTION
I think this would be a good tool to have in order to quickly view the lower storage slot values of contracts.