### PR TITLE
fix: emit the Safe Transaction Builder schema from SafeTxHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist
 
 .vscode
 package-lock.json
+
+# Test scratch output
+test/.tmp

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,9 @@
 src = 'src'
 out = 'out'
 libs = ["node_modules"]
+# Scratch space for the SafeTxHelper tests. The helper itself writes wherever
+# its caller points it; consumers grant permission for their own output path.
+fs_permissions = [{ access = "read-write", path = "./test/.tmp" }]
 [lint]
 exclude_lints = ["unsafe-typecast", "incorrect-shift"]
 

--- a/src/SafeTxHelper.sol
+++ b/src/SafeTxHelper.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import { Script } from "forge-std/Script.sol";
-import { stdJson } from "forge-std/StdJson.sol";
 import { Strings } from "./@openzeppelin/contracts-5.4.0/utils/Strings.sol";
 
 struct SafeTx {
@@ -12,57 +11,141 @@ struct SafeTx {
     bytes data;
 }
 
+/// @notice Optional batch-level metadata. Every field is written into the `meta`
+///         object of the Safe Transaction Builder file.
+/// @param safe         The Safe the batch is meant for. Written as
+///                     `meta.createdFromSafeAddress`. A batch is only a
+///                     transaction once it is bound to a Safe, so recording it
+///                     here keeps the artifact self-describing.
+/// @param name         Batch name shown in the Safe UI.
+/// @param description  Batch description shown in the Safe UI.
+/// @param createdAt    Creation time in milliseconds. Left at 0 the output is
+///                     byte-reproducible, so two runs of the same script produce
+///                     identical files that can be diffed or hashed.
+struct SafeBatchMeta {
+    address safe;
+    string name;
+    string description;
+    uint256 createdAt;
+}
+
+/// @title SafeTxHelper
+/// @notice Writes a batch of transactions as a Safe{Wallet} Transaction Builder
+///         JSON file, ready to be imported into the Safe UI.
+///
+///         The output follows the Transaction Builder schema, as defined by
+///         `BatchFile` in safe-global/safe-react-apps:
+///
+///         {
+///           "version": "1.0",
+///           "chainId": "1",
+///           "createdAt": 0,
+///           "meta": { "name", "description", "createdFromSafeAddress", "txBuilderVersion" },
+///           "transactions": [ { "to", "value", "data", "contractMethod", "contractInputsValues" } ]
+///         }
 contract SafeTxHelper is Script {
-    using stdJson for string;
+    /// @dev Reported as `meta.txBuilderVersion` so a consumer can tell which
+    ///      writer produced the file.
+    string internal constant TX_BUILDER_VERSION = "frax-standard-solidity";
 
+    /// @notice Write `txs` to `path` without binding the batch to a Safe.
+    /// @dev Prefer the overload taking a Safe address: without it the file cannot
+    ///      say which Safe it belongs to, and the same batch is a different
+    ///      transaction on a different Safe.
     function writeTxs(SafeTx[] memory txs, string memory path) public {
-        string memory json = "json";
-        // Default values
-        vm.serializeString(json, "version", "1.0");
-        vm.serializeUint(json, "chainId", block.chainid);
-        vm.serializeUint(json, "createdAt", block.timestamp * 1000);
+        writeTxs(txs, path, address(0));
+    }
 
-        string memory safeTxs = "[";
-        for (uint256 i = 0; i < txs.length; i++) {
-            if (i != 0) {
-                safeTxs = string.concat(safeTxs, ",");
-            }
+    /// @notice Write `txs` to `path`, recorded as created from `safe`.
+    function writeTxs(SafeTx[] memory txs, string memory path, address safe) public {
+        writeTxs(txs, path, SafeBatchMeta({ safe: safe, name: "Transactions Batch", description: "", createdAt: 0 }));
+    }
 
-            string memory transaction = "tx";
-            vm.serializeAddress(transaction, "to", txs[i].to);
-            vm.serializeString(transaction, "value", Strings.toString(txs[i].value));
-            vm.serializeInt(transaction, "operation", 0);
-            string memory serializedTx = vm.serializeBytes(transaction, "data", txs[i].data);
+    /// @notice Write `txs` to `path` with full control over the batch metadata.
+    function writeTxs(SafeTx[] memory txs, string memory path, SafeBatchMeta memory meta) public {
+        // Built by direct concatenation rather than `vm.serialize*`: the
+        // transaction list is itself JSON, and serialising it as a string escapes
+        // it, which then has to be un-escaped again. Emitting the bytes directly
+        // keeps the output exact and needs no post-processing.
+        string memory json = string.concat(
+            "{\n",
+            '  "version": "1.0",\n',
+            '  "chainId": "',
+            Strings.toString(block.chainid),
+            '",\n',
+            '  "createdAt": ',
+            Strings.toString(meta.createdAt),
+            ",\n",
+            _metaJson(meta),
+            ',\n  "transactions": [\n',
+            _transactionsJson(txs),
+            "\n  ]\n",
+            "}\n"
+        );
 
-            safeTxs = string.concat(safeTxs, serializedTx);
+        vm.writeFile(path, json);
+    }
+
+    /// @dev The `meta` object. `createdFromSafeAddress` is omitted rather than
+    ///      written as the zero address when no Safe was supplied, so a consumer
+    ///      can tell "unbound" apart from "bound to 0x0".
+    function _metaJson(SafeBatchMeta memory meta) internal view returns (string memory json) {
+        json = string.concat(
+            '  "meta": {\n    "name": "',
+            _escape(meta.name),
+            '",\n    "description": "',
+            _escape(meta.description),
+            '",\n'
+        );
+
+        if (meta.safe != address(0)) {
+            json = string.concat(json, '    "createdFromSafeAddress": "', vm.toString(meta.safe), '",\n');
         }
-        safeTxs = string.concat(safeTxs, "]");
 
-        string memory meta = "meta";
-        vm.serializeString(meta, "name", "Transactions Batch");
-        string memory serializedMeta = vm.serializeString(meta, "description", "");
+        json = string.concat(json, '    "txBuilderVersion": "', TX_BUILDER_VERSION, '"\n  }');
+    }
 
-        vm.serializeString(json, "transactions", safeTxs);
-        string memory finalJson = vm.serializeString(json, "meta", serializedMeta);
+    /// @dev The `transactions` array. `contractMethod` and `contractInputsValues`
+    ///      are null because the calldata is already encoded — the Safe UI only
+    ///      uses those to re-encode a call from an ABI plus input values.
+    function _transactionsJson(SafeTx[] memory txs) internal view returns (string memory json) {
+        for (uint256 i = 0; i < txs.length; i++) {
+            json = string.concat(
+                json,
+                '    {\n      "to": "',
+                vm.toString(txs[i].to),
+                '",\n      "value": "',
+                Strings.toString(txs[i].value),
+                '",\n      "data": "',
+                vm.toString(txs[i].data),
+                '",\n      "contractMethod": null,\n      "contractInputsValues": null\n    }',
+                i + 1 < txs.length ? ",\n" : ""
+            );
+        }
+    }
 
-        vm.writeJson({ json: finalJson, path: path });
-
-        string[] memory commands = new string[](4);
-        // re-used commands to find-replace
-        commands[0] = "sed";
-        commands[1] = "-i";
-        commands[3] = path;
-
-        // Remove all backslashes
-        commands[2] = "s/\\\\//g";
-        vm.ffi(commands);
-
-        // Replace `"[` with `[`]
-        commands[2] = 's/\\"\\[/\\[/g';
-        vm.ffi(commands);
-
-        // Replace `]"` with `]`
-        commands[2] = 's/\\]\\"/\\]/g';
-        vm.ffi(commands);
+    /// @dev Escape the characters JSON forbids raw inside a string. Batch names
+    ///      and descriptions are caller-supplied, and an unescaped quote would
+    ///      produce a file the Safe UI cannot parse.
+    function _escape(string memory input) internal pure returns (string memory output) {
+        bytes memory data = bytes(input);
+        for (uint256 i = 0; i < data.length; i++) {
+            bytes1 char = data[i];
+            if (char == '"') {
+                output = string.concat(output, '\\"');
+            } else if (char == "\\") {
+                output = string.concat(output, "\\\\");
+            } else if (char == "\n") {
+                output = string.concat(output, "\\n");
+            } else if (char == "\r") {
+                output = string.concat(output, "\\r");
+            } else if (char == "\t") {
+                output = string.concat(output, "\\t");
+            } else if (uint8(char) < 0x20) {
+                output = string.concat(output, "\\u00", Strings.toHexString(uint8(char), 1));
+            } else {
+                output = string.concat(output, string(abi.encodePacked(char)));
+            }
+        }
     }
 }

--- a/test/TestSafeTxHelper.t.sol
+++ b/test/TestSafeTxHelper.t.sol
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: ISC
+pragma solidity >=0.8.0;
+
+import "../src/FraxTest.sol";
+import { SafeTxHelper, SafeTx, SafeBatchMeta } from "../src/SafeTxHelper.sol";
+
+contract TestSafeTxHelper is FraxTest {
+    SafeTxHelper internal helper;
+
+    string internal constant OUT_DIR = "test/.tmp";
+
+    function setUp() public {
+        helper = new SafeTxHelper();
+        vm.createDir(OUT_DIR, true);
+    }
+
+    function _path(string memory name) internal pure returns (string memory) {
+        return string.concat(OUT_DIR, "/", name, ".json");
+    }
+
+    function _twoTxs() internal pure returns (SafeTx[] memory txs) {
+        txs = new SafeTx[](2);
+        txs[0] = SafeTx({
+            name: "approve",
+            to: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,
+            value: 0,
+            data: abi.encodeWithSignature("approve(address,uint256)", address(0xBEEF), 0)
+        });
+        txs[1] = SafeTx({
+            name: "transfer",
+            to: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,
+            value: 1 ether,
+            data: abi.encodeWithSignature("transfer(address,uint256)", address(0xDEAD), 1e6)
+        });
+    }
+
+    /// @notice The file must match the Transaction Builder schema: `chainId` is a
+    ///         string, `createdAt` a number, and every transaction carries the
+    ///         five keys the Safe UI reads.
+    function testWritesTransactionBuilderSchema() public {
+        SafeTx[] memory txs = _twoTxs();
+        string memory path = _path("schema");
+        helper.writeTxs(txs, path, address(0xABCD));
+
+        string memory json = vm.readFile(path);
+
+        assertEq(vm.parseJsonString(json, ".version"), "1.0");
+        assertEq(vm.parseJsonString(json, ".chainId"), Strings.toString(block.chainid));
+        assertEq(vm.parseJsonUint(json, ".createdAt"), 0);
+        assertEq(vm.parseJsonString(json, ".meta.name"), "Transactions Batch");
+        assertEq(vm.parseJsonString(json, ".meta.description"), "");
+
+        assertEq(vm.parseJsonAddress(json, ".transactions[0].to"), txs[0].to);
+        assertEq(vm.parseJsonString(json, ".transactions[0].value"), "0");
+        assertEq(vm.parseJsonBytes(json, ".transactions[0].data"), txs[0].data);
+
+        assertEq(vm.parseJsonAddress(json, ".transactions[1].to"), txs[1].to);
+        assertEq(vm.parseJsonString(json, ".transactions[1].value"), "1000000000000000000");
+        assertEq(vm.parseJsonBytes(json, ".transactions[1].data"), txs[1].data);
+
+        assertTrue(vm.keyExistsJson(json, ".transactions[1].contractMethod"), "contractMethod key");
+        assertTrue(vm.keyExistsJson(json, ".transactions[1].contractInputsValues"), "inputs key");
+    }
+
+    /// @notice The Safe address is what binds a batch to a transaction; without it
+    ///         the same file is a different transaction on every Safe.
+    function testRecordsTheSafeAddress() public {
+        address safe = 0x111CEEee040739fD91D29C34C33E6B3E112F2177;
+        string memory path = _path("bound");
+        helper.writeTxs(_twoTxs(), path, safe);
+
+        assertEq(vm.parseJsonAddress(vm.readFile(path), ".meta.createdFromSafeAddress"), safe);
+    }
+
+    /// @notice With no Safe, the key is absent rather than zero — "unbound" and
+    ///         "bound to 0x0" must not look the same.
+    function testOmitsSafeAddressWhenUnbound() public {
+        string memory path = _path("unbound");
+        helper.writeTxs(_twoTxs(), path);
+
+        assertFalse(vm.keyExistsJson(vm.readFile(path), ".meta.createdFromSafeAddress"), "should be absent");
+    }
+
+    /// @notice Same inputs, same bytes. A batch you cannot reproduce is a batch you
+    ///         cannot review by diffing or pin by hash.
+    function testOutputIsReproducible() public {
+        string memory a = _path("repro-a");
+        string memory b = _path("repro-b");
+
+        helper.writeTxs(_twoTxs(), a, address(0xABCD));
+        vm.warp(block.timestamp + 3 days);
+        helper.writeTxs(_twoTxs(), b, address(0xABCD));
+
+        assertEq(keccak256(bytes(vm.readFile(a))), keccak256(bytes(vm.readFile(b))));
+    }
+
+    /// @notice An explicit timestamp is still available for anyone who wants one.
+    function testHonoursAnExplicitCreatedAt() public {
+        string memory path = _path("stamped");
+        helper.writeTxs(
+            _twoTxs(),
+            path,
+            SafeBatchMeta({ safe: address(0xABCD), name: "Batch", description: "", createdAt: 1760128999000 })
+        );
+
+        assertEq(vm.parseJsonUint(vm.readFile(path), ".createdAt"), 1760128999000);
+    }
+
+    /// @notice Names and descriptions are caller-supplied, so quotes and backslashes
+    ///         have to survive into valid JSON rather than break the file.
+    function testEscapesMetadataStrings() public {
+        string memory name = 'Upgrade "V110" \\ destinations';
+        string memory description = "line one\nline two\ttabbed";
+        string memory path = _path("escaped");
+
+        helper.writeTxs(
+            _twoTxs(),
+            path,
+            SafeBatchMeta({ safe: address(0xABCD), name: name, description: description, createdAt: 0 })
+        );
+
+        string memory json = vm.readFile(path);
+        assertEq(vm.parseJsonString(json, ".meta.name"), name);
+        assertEq(vm.parseJsonString(json, ".meta.description"), description);
+    }
+
+    function testWritesASingleTransaction() public {
+        SafeTx[] memory txs = new SafeTx[](1);
+        txs[0] = SafeTx({ name: "noop", to: address(0xFEED), value: 0, data: "" });
+
+        string memory path = _path("single");
+        helper.writeTxs(txs, path, address(0xABCD));
+
+        string memory json = vm.readFile(path);
+        assertEq(vm.parseJsonAddress(json, ".transactions[0].to"), address(0xFEED));
+        assertEq(vm.parseJsonString(json, ".transactions[0].data"), "0x");
+        assertFalse(vm.keyExistsJson(json, ".transactions[1].to"), "only one transaction");
+    }
+
+    function testWritesAnEmptyBatch() public {
+        string memory path = _path("empty");
+        helper.writeTxs(new SafeTx[](0), path, address(0xABCD));
+
+        assertFalse(vm.keyExistsJson(vm.readFile(path), ".transactions[0].to"), "no transactions");
+    }
+}


### PR DESCRIPTION
`writeTxs` produced a file close to, but not quite, the Transaction Builder format, and post-processed it by shelling out to `sed`. Four consequences:

1. The Safe address is nowhere in the file. The schema has a slot for it — `meta.createdFromSafeAddress` — and it matters: a batch is not yet a transaction. It becomes one only when bound to a Safe at a nonce and folded into a `multiSend` delegatecall. The same batch on a different Safe is a different transaction, and the artifact could not say which.

2. `createdAt` was `block.timestamp * 1000`, so a batch regenerated from the same script is a different file. That makes runs undiffable and output hashes unpinnable. It now defaults to 0 and is settable via `SafeBatchMeta` for anyone who wants a real stamp.

3. `vm.ffi` + `sed -i` existed only to undo forge's escaping of the transaction list, which had been serialised as a string. It required `--ffi` (not enabled in this repo's foundry.toml, so the helper could not be covered by CI), assumed GNU `sed -i`, and `s/\\//g` stripped every backslash in the file — corrupting any escaped character in a name or description. Building the JSON directly needs none of it.

4. `chainId` was a number and each transaction carried a non-schema `operation` key hardcoded to `"0"`. `BatchFile` types `chainId` as a string and has no `operation`; the Transaction Builder always executes CALLs. `contractMethod` and `contractInputsValues` are now present and null, as the schema expects for pre-encoded calldata.

Existing call sites keep compiling: `SafeTx` is untouched and `writeTxs(txs, path)` still works. New overloads take a Safe address, or a `SafeBatchMeta` for full control. Caller-supplied strings are now escaped properly rather than stripped.

Adds test/TestSafeTxHelper.t.sol — 8 tests covering the schema, Safe binding, reproducibility and escaping. They run under plain `forge test` with no `--ffi`, so CI exercises this for the first time. The tests need somewhere to write, so foundry.toml grants `fs_permissions` on the gitignored `test/.tmp` scratch directory and nothing wider; consumers grant their own permission for wherever they point `writeTxs`.